### PR TITLE
Fix Claude multi-account Keychain lookup

### DIFF
--- a/host/detect_sources.py
+++ b/host/detect_sources.py
@@ -15,31 +15,13 @@ import app_config
 import copilot_usage
 import gemini_usage
 import jetbrains_usage
+import oauth_usage
 import windsurf_usage
 import zed_usage
 
 
 def claude_signed_in():
-    try:
-        raw = subprocess.check_output(
-            ["security", "find-generic-password",
-             "-s", "Claude Code-credentials", "-w"],
-            stderr=subprocess.DEVNULL, text=True,
-        ).strip()
-        if raw:
-            blob = json.loads(raw)
-            if (blob.get("claudeAiOauth") or {}).get("accessToken"):
-                return True
-    except (subprocess.CalledProcessError, FileNotFoundError,
-            json.JSONDecodeError, TypeError):
-        pass
-    path = os.path.expanduser("~/.claude/.credentials.json")
-    try:
-        with open(path) as handle:
-            blob = json.load(handle)
-        return bool((blob.get("claudeAiOauth") or {}).get("accessToken"))
-    except (OSError, json.JSONDecodeError, TypeError):
-        return False
+    return oauth_usage.credentials_present()
 
 
 def codex_signed_in():

--- a/host/oauth_usage.py
+++ b/host/oauth_usage.py
@@ -1,12 +1,16 @@
 """Anthropic OAuth plan-usage fetcher (CodexBar-equivalent).
 
-Reads the Claude Code OAuth token from macOS Keychain
-(`Claude Code-credentials`) or `~/.claude/.credentials.json`, calls
-`GET https://api.anthropic.com/api/oauth/usage`, and returns session/weekly
-utilization + reset times. Refreshes the access token when expired/401 and
-writes it back to the same credential store — through the Security framework
-(see keychain.py), never through `security -w`, which would expose the token
-in the process table.
+Reads the Claude Code OAuth token from macOS Keychain or
+`~/.claude/.credentials.json`, calls `GET /api/oauth/usage`, and returns
+session/weekly utilization + reset times. Current Claude Code uses one
+Keychain service per config directory:
+
+    Claude Code-credentials-<sha256(config dir)[:8]>
+
+The old unqualified `Claude Code-credentials` service and credential files
+remain fallbacks. Refreshed tokens go back to the store they came from —
+through the Security framework (see keychain.py), never through `security -w`,
+which would expose the token in the process table.
 
 Stdlib only. The endpoint is undocumented and may change; failures degrade
 to an empty quota dict so the desk gadget still shows local cost data.
@@ -14,6 +18,7 @@ to an empty quota dict so the desk gadget still shows local cost data.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import subprocess
@@ -34,12 +39,15 @@ TOKEN_URLS = (
 CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 OAUTH_BETA = "oauth-2025-04-20"
 UA = "claude-cli/2.1.201 (external, cli)"
-# Claude Code keeps this inside its config directory, so a second login is a
-# second directory (`CLAUDE_CONFIG_DIR`) holding the same filename — see
-# accounts.py. The name lives here because the fetcher owns the layout.
+# Claude Code used to keep this inside its config directory. It remains a
+# fallback for older installs; current releases put the same payload in a
+# Keychain service derived from `CLAUDE_CONFIG_DIR`.
 CREDS_NAME = ".credentials.json"
-CREDS_FILE = os.path.expanduser(os.path.join("~/.claude", CREDS_NAME))
+CONFIG_DIR = os.path.expanduser("~/.claude")
+CREDS_FILE = os.path.join(CONFIG_DIR, CREDS_NAME)
 KEYCHAIN_SERVICE = "Claude Code-credentials"
+KEYCHAIN_SERVICE_PREFIX = KEYCHAIN_SERVICE + "-"
+KEYCHAIN_STORE_PREFIX = "keychain:"
 CACHE_TTL_S = 60
 FAIL_TTL_S = 20          # retry sooner after transient misses (429, etc.)
 EXPIRY_SKEW_S = 120
@@ -59,10 +67,32 @@ def _cache_for(account):
     return cache
 
 
-def _keychain_account():
+def _keychain_service(account=None):
+    """Claude Code's Keychain service for one config directory."""
+    config_dir = account.root if account else CONFIG_DIR
+    digest = hashlib.sha256(config_dir.encode("utf-8")).hexdigest()[:8]
+    return KEYCHAIN_SERVICE_PREFIX + digest
+
+
+def _keychain_store(service):
+    """Opaque store id that lets refresh write back to the same service."""
+    if service == KEYCHAIN_SERVICE:
+        return "keychain"
+    return KEYCHAIN_STORE_PREFIX + service
+
+
+def _service_from_store(store):
+    if store == "keychain":
+        return KEYCHAIN_SERVICE
+    if isinstance(store, str) and store.startswith(KEYCHAIN_STORE_PREFIX):
+        return store[len(KEYCHAIN_STORE_PREFIX):]
+    return None
+
+
+def _keychain_account(service=KEYCHAIN_SERVICE):
     try:
         out = subprocess.check_output(
-            ["security", "find-generic-password", "-s", KEYCHAIN_SERVICE],
+            ["security", "find-generic-password", "-s", service],
             stderr=subprocess.DEVNULL, text=True,
         )
     except (subprocess.CalledProcessError, FileNotFoundError):
@@ -81,11 +111,11 @@ def _creds_file(account=None):
     return account.child(CREDS_NAME) if account else CREDS_FILE
 
 
-def _read_keychain_blob():
+def _read_keychain_blob(service=KEYCHAIN_SERVICE):
     try:
         raw = subprocess.check_output(
             ["security", "find-generic-password",
-             "-s", KEYCHAIN_SERVICE, "-w"],
+             "-s", service, "-w"],
             stderr=subprocess.DEVNULL, text=True,
         ).strip()
     except (subprocess.CalledProcessError, FileNotFoundError):
@@ -107,12 +137,13 @@ def _read_file_blob(path):
 
 
 def _read_creds_blob(account=None):
-    """Return (store, blob_dict); store is 'keychain', a file path, or None.
+    """Return (store, blob_dict); store identifies a Keychain item or file.
 
-    Only the default login can come out of the Keychain — there is one
-    `Claude Code-credentials` item per Mac, and it belongs to whichever login
-    the CLI wrote last. An extra account is a directory by definition, so it
-    reads and writes its own file and never touches the shared item.
+    Current Claude Code gives every config directory its own hashed Keychain
+    service, which is what makes simultaneous `CLAUDE_CONFIG_DIR` logins
+    distinct. The default login also checks the old global service, and every
+    login checks its legacy credential file, so upgrades do not strand either
+    storage generation.
 
     A store that parses but carries no `claudeAiOauth.accessToken` is not an
     answer, so the search goes on rather than stopping at it. That item is
@@ -123,9 +154,12 @@ def _read_creds_blob(account=None):
     the first store that parsed is still returned, so the failure is reported
     against the place the credentials are supposed to be.
     """
-    stores = []
+    service = _keychain_service(account)
+    stores = [
+        (_keychain_store(service), _read_keychain_blob(service)),
+    ]
     if account is None:
-        stores.append(("keychain", _read_keychain_blob()))
+        stores.append(("keychain", _read_keychain_blob(KEYCHAIN_SERVICE)))
     path = _creds_file(account)
     stores.append((path, _read_file_blob(path)))
 
@@ -138,11 +172,12 @@ def _read_creds_blob(account=None):
 
 def _write_creds_blob(store, blob):
     raw = json.dumps(blob, separators=(",", ":"))
-    if store == "keychain":
-        acct = _keychain_account() or "Claude"
+    service = _service_from_store(store)
+    if service:
+        acct = _keychain_account(service) or "Claude"
         # Via the Security framework, not `security -w`, which would put the
         # refresh token in argv where any process can read it out of `ps`.
-        keychain.set_generic_password(KEYCHAIN_SERVICE, acct, raw)
+        keychain.set_generic_password(service, acct, raw)
         return
     tmp = store + ".tmp"
     with open(tmp, "w") as f:
@@ -156,6 +191,23 @@ def _oauth_block(blob):
     if not o.get("accessToken"):
         return None
     return o
+
+
+def credentials_present(account=None):
+    """Whether this config directory has a usable Claude OAuth token."""
+    _store, blob = _read_creds_blob(account)
+    return bool(_oauth_block(blob))
+
+
+def _credentials_hint(account=None):
+    path = _creds_file(account)
+    service = _keychain_service(account)
+    if account:
+        return f"Keychain service {service} or {path}"
+    return (
+        f"Keychain service {service}, legacy {KEYCHAIN_SERVICE}, "
+        f"or {path}"
+    )
 
 
 def _shape_hint(store, blob):
@@ -356,10 +408,7 @@ def fetch_quota(force=False, account=None):
         store, blob = _read_creds_blob(account)
         if not store:
             return _keep_stale(
-                f"no Claude credentials at {_creds_file(account)}"
-                if account
-                else "no Claude credentials "
-                     "(Keychain or ~/.claude/.credentials.json)")
+                f"no Claude credentials in {_credentials_hint(account)}")
         oauth = _oauth_block(blob)
         if not oauth:
             return _keep_stale(_shape_hint(store, blob))

--- a/host/sources_config.py
+++ b/host/sources_config.py
@@ -115,11 +115,15 @@ class Source(NamedTuple):
     # None means one login per Mac and Settings offers no Add button.
     account_kind: Optional[str] = None
     # Filename inside a KIND_DIR account, so Settings can say whether the
-    # folder someone picked actually holds credentials. The fetcher owns the
-    # constant; this is a reference to it, not a second copy.
+    # folder someone picked holds legacy file credentials. The fetcher owns
+    # the constant; this is a reference to it, not a second copy.
     account_file: Optional[str] = None
     # What Settings shows as the example location for a new account.
     account_hint: Optional[str] = None
+    # Optional provider-owned credential probe. Claude needs this because
+    # current Claude Code stores one hashed Keychain item per config directory
+    # instead of a file inside that directory.
+    account_probe: Optional[Callable] = None
     # Set on rows the expansion created; None on the default login.
     account: Optional[object] = None
 
@@ -361,7 +365,8 @@ BASE_SOURCES = (
            headline=("week", "session"), accent="#D97757",
            account_kind=accounts.KIND_DIR,
            account_file=oauth_usage.CREDS_NAME,
-           account_hint="~/.claude-work (a second CLAUDE_CONFIG_DIR)"),
+           account_hint="~/.claude-work (a second CLAUDE_CONFIG_DIR)",
+           account_probe=oauth_usage.credentials_present),
     Source("codex", "Codex", "~/.codex/auth.json", 60,
            codex_usage.fetch_quota, summary_fn=_summary_codex,
            kind="quota", group=GROUP_AI, pools=_CODEX_POOLS,
@@ -637,8 +642,11 @@ def _default_enabled():
     for source in SOURCES:
         if source.account is None:
             continue
-        enabled[source.id] = accounts.present(
-            source.account, source.account_kind, source.account_file)
+        if source.account_probe is not None:
+            enabled[source.id] = bool(source.account_probe(source.account))
+        else:
+            enabled[source.id] = accounts.present(
+                source.account, source.account_kind, source.account_file)
     return enabled
 
 
@@ -880,8 +888,11 @@ def _detected_map():
     for source in SOURCES:
         if source.account is None:
             continue
-        detected[source.id] = accounts.present(
-            source.account, source.account_kind, source.account_file)
+        if source.account_probe is not None:
+            detected[source.id] = bool(source.account_probe(source.account))
+        else:
+            detected[source.id] = accounts.present(
+                source.account, source.account_kind, source.account_file)
     return detected
 
 

--- a/host/test_accounts.py
+++ b/host/test_accounts.py
@@ -120,6 +120,22 @@ class AccountsTests(unittest.TestCase):
         self.assertIn(
             "claude:empty", [row["id"] for row in payload["sources"]])
 
+    def test_detection_probes_the_account_keychain_service(self):
+        account = sources_config.add_account(
+            "claude", "Keychain", self._claude_dir(
+                "keychain", signed_in=False))
+        sources_config.reload_registry()
+        service = oauth_usage._keychain_service(account)
+        good = {"claudeAiOauth": {"accessToken": "plan-token"}}
+
+        def keychain_blob(wanted):
+            return good if wanted == service else None
+
+        with patch.object(oauth_usage, "_read_keychain_blob",
+                          side_effect=keychain_blob):
+            payload = sources_config.detection_payload()
+        self.assertTrue(payload["detected"]["claude:keychain"])
+
     def test_reseeding_keeps_a_signed_in_account_on(self):
         sources_config.add_account("claude", "Work", self._claude_dir())
         sources_config.reload_registry()
@@ -128,6 +144,24 @@ class AccountsTests(unittest.TestCase):
         os.remove(sources_config.STORE_PATH)
         sources_config.reset_for_tests()
         self.assertTrue(sources_config.enabled_map()["claude:work"])
+
+    def test_reseeding_keeps_a_keychain_account_on(self):
+        account = sources_config.add_account(
+            "claude", "Keychain", self._claude_dir(
+                "keychain-seed", signed_in=False))
+        sources_config.reload_registry()
+        service = oauth_usage._keychain_service(account)
+        good = {"claudeAiOauth": {"accessToken": "plan-token"}}
+        os.remove(sources_config.STORE_PATH)
+        sources_config.reset_for_tests()
+
+        def keychain_blob(wanted):
+            return good if wanted == service else None
+
+        with patch.object(oauth_usage, "_read_keychain_blob",
+                          side_effect=keychain_blob):
+            self.assertTrue(
+                sources_config.enabled_map()["claude:keychain"])
 
     def test_setup_payload_lists_who_can_hold_accounts(self):
         providers = sources_config.accounts_payload()["providers"]

--- a/host/test_detect_sources.py
+++ b/host/test_detect_sources.py
@@ -11,10 +11,17 @@ from pathlib import Path
 from unittest.mock import patch
 
 import detect_sources
+import oauth_usage
 import sources_config
 
 
 class DetectSourcesTests(unittest.TestCase):
+    def test_claude_detection_uses_the_fetchers_credential_search(self):
+        with patch.object(oauth_usage, "credentials_present",
+                          return_value=True) as present:
+            self.assertTrue(detect_sources.claude_signed_in())
+        present.assert_called_once_with()
+
     def test_suggested_enables_detected_only(self):
         with patch.object(detect_sources, "detected_map", return_value={
             "claude": True,

--- a/host/test_stale_quota.py
+++ b/host/test_stale_quota.py
@@ -17,6 +17,7 @@ import time
 import unittest
 from unittest.mock import patch
 
+import accounts
 import burndown
 import cache_util
 import headroom_server
@@ -49,6 +50,34 @@ class CredentialSearchTests(unittest.TestCase):
     GOOD = {"claudeAiOauth": {"accessToken": "plan-token",
                               "refreshToken": "r"}}
 
+    @staticmethod
+    def _account(root="/Users/example/.claudewho-work"):
+        return accounts.Account(
+            provider="claude",
+            slug="work",
+            label="Work",
+            root=root,
+            raw_root=root,
+        )
+
+    def test_profile_keychain_service_hashes_the_config_directory(self):
+        service = oauth_usage._keychain_service(self._account())
+        self.assertEqual(service, "Claude Code-credentials-abfbd7ee")
+
+    def test_profile_reads_its_own_hashed_keychain_item(self):
+        account = self._account()
+        service = oauth_usage._keychain_service(account)
+
+        def keychain_blob(wanted):
+            return self.GOOD if wanted == service else None
+
+        with patch.object(oauth_usage, "_read_keychain_blob",
+                          side_effect=keychain_blob):
+            store, blob = oauth_usage._read_creds_blob(account)
+        self.assertEqual(store, f"keychain:{service}")
+        self.assertEqual(oauth_usage._oauth_block(blob)["accessToken"],
+                         "plan-token")
+
     def test_keychain_without_plan_token_falls_through_to_file(self):
         # The real shape that broke it: Claude Code keeps per-MCP-server OAuth
         # in the same Keychain item, and a blob left holding only `mcpOAuth`
@@ -65,21 +94,47 @@ class CredentialSearchTests(unittest.TestCase):
         self.assertEqual(oauth_usage._oauth_block(blob)["accessToken"],
                          "plan-token")
 
-    def test_keychain_wins_when_it_has_the_token(self):
-        # Unchanged from before: the Keychain is still the preferred store, so
-        # a refresh writes back where the CLI expects it.
+    def test_legacy_keychain_remains_a_default_login_fallback(self):
+        hashed = oauth_usage._keychain_service()
+
+        def keychain_blob(service):
+            if service == hashed:
+                return None
+            if service == oauth_usage.KEYCHAIN_SERVICE:
+                return self.GOOD
+            return None
+
         with patch.object(oauth_usage, "_read_keychain_blob",
-                          return_value=self.GOOD), \
+                          side_effect=keychain_blob), \
              patch.object(oauth_usage, "CREDS_FILE", "/nonexistent/creds"):
             store, blob = oauth_usage._read_creds_blob()
         self.assertEqual(store, "keychain")
         self.assertTrue(oauth_usage._oauth_block(blob))
 
+    def test_hashed_keychain_wins_for_the_default_login(self):
+        hashed = oauth_usage._keychain_service()
+
+        def keychain_blob(service):
+            return self.GOOD if service == hashed else None
+
+        with patch.object(oauth_usage, "_read_keychain_blob",
+                          side_effect=keychain_blob), \
+             patch.object(oauth_usage, "CREDS_FILE", "/nonexistent/creds"):
+            store, blob = oauth_usage._read_creds_blob()
+        self.assertEqual(store, f"keychain:{hashed}")
+        self.assertTrue(oauth_usage._oauth_block(blob))
+
     def test_token_nowhere_still_reports_against_a_real_store(self):
         # Nothing to find, but the error has to name a place that exists or it
         # reads as "Headroom lost your credentials".
+
+        def keychain_blob(service):
+            if service == oauth_usage.KEYCHAIN_SERVICE:
+                return self.MCP_ONLY
+            return None
+
         with patch.object(oauth_usage, "_read_keychain_blob",
-                          return_value=self.MCP_ONLY), \
+                          side_effect=keychain_blob), \
              patch.object(oauth_usage, "CREDS_FILE", "/nonexistent/creds"):
             store, blob = oauth_usage._read_creds_blob()
         self.assertEqual(store, "keychain")
@@ -90,6 +145,17 @@ class CredentialSearchTests(unittest.TestCase):
                           return_value=None), \
              patch.object(oauth_usage, "CREDS_FILE", "/nonexistent/creds"):
             self.assertEqual(oauth_usage._read_creds_blob(), (None, None))
+
+    def test_refresh_writes_back_to_the_profile_keychain_service(self):
+        service = oauth_usage._keychain_service(self._account())
+        store = f"keychain:{service}"
+        with patch.object(oauth_usage, "_keychain_account",
+                          return_value="profile-account"), \
+             patch.object(oauth_usage.keychain, "set_generic_password") as put:
+            oauth_usage._write_creds_blob(store, self.GOOD)
+        put.assert_called_once()
+        self.assertEqual(put.call_args.args[:2],
+                         (service, "profile-account"))
 
 
 class StaleAgeTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- read Claude Code's hashed Keychain service for each config directory
- preserve legacy credential fallbacks and refresh tokens in the originating store
- use the same lookup for account detection and reseeding

## Testing
- 289 host tests
- 37 macOS tests
- glossary copy check