### PR TITLE
fix(ci): iOS archive manual signing (TestFlight)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,7 +320,9 @@ jobs:
       # Without this the export asks for a distribution identity the runner has
       # never had, and fails with "Cloud signing permission error". Every such
       # run also leaves another "Created via API" development cert behind,
-      # against the team's cap. Import the real identity instead.
+      # against the team's cap — and once the cap is hit, even the *archive*
+      # fails (build-ios.sh --manual-signing signs the archive too). Import the
+      # real identity instead.
       - name: Import Apple Distribution certificate
         id: ioscert
         if: steps.asc.outputs.ready == 'true'

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -178,13 +178,20 @@ key of any role can mint an **Apple Distribution** certificate — a key creates
 distribution identity, export fails with `Cloud signing permission error` /
 `No profiles for 'com.centaur-labs.headroom' were found` no matter how
 privileged the key is; an App Manager key was tried on 2026-07-29 and failed
-identically to the Developer one. The archive succeeds first, which is what
-makes it read as a build problem rather than a credentials one. The fix is
-`IOS_DISTRIBUTION_P12` below.
+identically to the Developer one.
 
-Each failed attempt also leaves a `Created via API` development certificate on
-the account, so a run of red releases quietly walks the team toward its
-certificate cap. They are safe to revoke.
+Worse: passing the key into an **Automatic**-signing *archive* makes Xcode
+mint a fresh `Created via API` development certificate on every run. That is
+what walks the team to its certificate cap, after which the archive itself
+fails with `Choose a certificate to revoke` and looks for **iOS App
+Development** profiles that CI never installed. CI therefore archives with
+`--manual-signing` (Distribution identity + named App Store profiles, no API
+key on `xcodebuild`) and only uses the key for `asc` upload.
+
+`IOS_DISTRIBUTION_P12` is still required for the Distribution identity. Leftover
+`Created via API` development certificates are safe to revoke under
+[Certificates](https://developer.apple.com/account/resources/certificates/list)
+if the team is already at its cap.
 
 ### 3. GitHub Actions secrets
 

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -34,8 +34,10 @@ Archive HeadroomMobile for App Store / TestFlight.
   ./scripts/build-ios.sh          # → dist/Headroom-iOS.ipa
   ./scripts/build-ios.sh --upload # export + asc publish → Internal group
 
-  --manual-signing  export against named App Store profiles instead of letting
-                    Xcode manage them (CI — see the profile map below)
+  --manual-signing  archive + export against named App Store profiles instead
+                    of letting Xcode manage them (CI — see the profile map
+                    below). Avoids minting iOS Development certificates via
+                    the ASC API key.
 EOF
       exit 0
       ;;
@@ -100,20 +102,29 @@ if [[ "$MANUAL_SIGNING" -eq 1 ]]; then
   done
   echo "Exporting with manual signing:"
   /usr/libexec/PlistBuddy -c "Print :provisioningProfiles" "$EXPORT_OPTIONS_RESOLVED"
+  # Archive must match. Automatic + an ASC API key mints iOS Development
+  # certificates on every run until the team hits Apple's cap, and then the
+  # archive fails asking you to revoke one (docs/releasing.md).
+  python3 "$ROOT/scripts/ios_manual_sign_pbxproj.py" \
+    "$ROOT/macos/Headroom.xcodeproj/project.pbxproj"
 fi
 
 echo "Archiving HeadroomMobile $HEADROOM_VERSION ($HEADROOM_BUILD)"
 
-# Let Xcode mint the missing App Store profiles either way. On CI that needs
-# the ASC key appended below; on a Mac with an Apple Distribution certificate
-# the signed-in Xcode account does it, and passing a key would override the
-# account with something weaker (see scripts/ship-ios.sh).
-AUTH_ARGS=(-allowProvisioningUpdates)
+# Local Macs: let the signed-in Xcode account mint/refresh App Store profiles
+# (-allowProvisioningUpdates, no API key — see scripts/ship-ios.sh).
+# CI --manual-signing: profiles and the Distribution identity are already on
+# the runner; do NOT pass the ASC key or -allowProvisioningUpdates, or Xcode
+# reaches for Development certificates again.
+AUTH_ARGS=()
+if [[ "$MANUAL_SIGNING" -eq 0 ]]; then
+  AUTH_ARGS=(-allowProvisioningUpdates)
+fi
 key_path="${APPLE_API_KEY_PATH:-}"
 key_id="${APPLE_API_KEY_ID:-}"
 issuer="${APPLE_API_ISSUER_ID:-}"
 tmp_auth_key=""
-if [[ -n "$key_id" && -n "$issuer" ]]; then
+if [[ "$MANUAL_SIGNING" -eq 0 && -n "$key_id" && -n "$issuer" ]]; then
   if [[ -z "$key_path" && -n "${APPLE_API_KEY:-}" ]]; then
     # The .p8 suffix means this is a new path, not the file mktemp created and
     # locked down — so it lands under the default umask. asc refuses a key it
@@ -129,6 +140,16 @@ if [[ -n "$key_id" && -n "$issuer" ]]; then
       -authenticationKeyID "$key_id"
       -authenticationKeyIssuerID "$issuer"
     )
+  fi
+fi
+
+# Upload still needs the ASC key even when signing is manual.
+if [[ "$MANUAL_SIGNING" -eq 1 && "$UPLOAD" -eq 1 ]]; then
+  if [[ -z "$key_path" && -n "${APPLE_API_KEY:-}" && -n "$key_id" && -n "$issuer" ]]; then
+    tmp_auth_key="$(mktemp -t AuthKey).p8"
+    printf '%s\n' "$APPLE_API_KEY" > "$tmp_auth_key"
+    chmod 600 "$tmp_auth_key"
+    key_path="$tmp_auth_key"
   fi
 fi
 

--- a/scripts/ios_manual_sign_pbxproj.py
+++ b/scripts/ios_manual_sign_pbxproj.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Force Manual + Apple Distribution + named App Store profiles on iOS targets.
+
+XcodeGen ships CODE_SIGN_STYLE=Automatic so local Macs keep working. CI archives
+with an ASC API key under Automatic mint *development* certificates until the
+team hits Apple's cap — see docs/releasing.md. After xcodegen, the Release
+workflow calls this so the archive signs the same way the export already does.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+# Target name → App Store Connect provisioning profile name (must match
+# scripts/build-ios.sh PROFILE_BUNDLES and the Release workflow download list).
+PROFILES = {
+    "HeadroomMobile": "Headroom App Store",
+    "HeadroomWidget": "Headroom Widget App Store",
+    "HeadroomWatch": "Headroom Watch App Store",
+    "HeadroomWatchComplication": "Headroom Watch Complication App Store",
+}
+
+SETTINGS = {
+    "CODE_SIGN_STYLE": "Manual",
+    "CODE_SIGN_IDENTITY": '"Apple Distribution"',
+    "CODE_SIGN_IDENTITY[sdk=iphoneos*]": '"Apple Distribution"',
+    "CODE_SIGN_IDENTITY[sdk=watchos*]": '"Apple Distribution"',
+}
+
+
+def _target_config_ids(text: str, target: str) -> list[str]:
+    """Return XCConfigurationList id for PBXNativeTarget `target`."""
+    pattern = (
+        rf'/\* {re.escape(target)} \*/ = \{{.*?buildConfigurationList = '
+        rf'([0-9A-F]+) /\* Build configuration list for PBXNativeTarget '
+        rf'"{re.escape(target)}" \*/;'
+    )
+    match = re.search(pattern, text, re.S)
+    if not match:
+        raise SystemExit(f"error: target {target!r} not found in pbxproj")
+    list_id = match.group(1)
+    list_pat = (
+        rf'{list_id} /\* Build configuration list for PBXNativeTarget '
+        rf'"{re.escape(target)}" \*/ = \{{.*?buildConfigurations = \((.*?)\);'
+    )
+    list_match = re.search(list_pat, text, re.S)
+    if not list_match:
+        raise SystemExit(f"error: configuration list for {target!r} not found")
+    return re.findall(r'([0-9A-F]+) /\* (Debug|Release) \*/', list_match.group(1))
+
+
+def _patch_config(text: str, config_id: str, config_name: str, profile: str) -> str:
+    """Rewrite one XCBuildConfiguration's buildSettings block."""
+    pattern = (
+        rf'({config_id} /\* {config_name} \*/ = \{{.*?buildSettings = \{{)'
+        rf'(.*?)(\n\t\t\t\}};.*?name = {config_name};)'
+    )
+    match = re.search(pattern, text, re.S)
+    if not match:
+        raise SystemExit(
+            f"error: build settings for {config_id} ({config_name}) not found")
+    settings = match.group(2)
+    # Drop any existing keys we own so re-runs stay idempotent.
+    for key in (
+        "CODE_SIGN_STYLE",
+        "CODE_SIGN_IDENTITY",
+        "CODE_SIGN_IDENTITY\\[sdk=iphoneos\\*\\]",
+        "CODE_SIGN_IDENTITY\\[sdk=watchos\\*\\]",
+        "PROVISIONING_PROFILE_SPECIFIER",
+    ):
+        settings = re.sub(
+            rf'\n\t\t\t\t{key} = .*?;',
+            "",
+            settings,
+        )
+    extras = "".join(
+        f"\n\t\t\t\t{key} = {value};"
+        for key, value in SETTINGS.items()
+    )
+    extras += f'\n\t\t\t\tPROVISIONING_PROFILE_SPECIFIER = "{profile}";'
+    patched = match.group(1) + settings + extras + match.group(3)
+    return text[: match.start()] + patched + text[match.end() :]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "pbxproj",
+        type=pathlib.Path,
+        help="path to project.pbxproj",
+    )
+    args = parser.parse_args()
+    path = args.pbxproj
+    text = path.read_text()
+    for target, profile in PROFILES.items():
+        for config_id, config_name in _target_config_ids(text, target):
+            text = _patch_config(text, config_id, config_name, profile)
+            print(f"signed {target} {config_name} → {profile}")
+    path.write_text(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ship-ios.sh
+++ b/scripts/ship-ios.sh
@@ -4,11 +4,9 @@
 #   ./scripts/ship-ios.sh             # archive, export, upload
 #   ./scripts/ship-ios.sh --dry-run   # stop after dist/Headroom-iOS.ipa
 #
-# CI cannot do this. The Release workflow's iOS job archives fine and then
-# fails at export with "Cloud signing permission error", because its App Store
-# Connect key holds the Developer role and that role cannot mint distribution
-# provisioning profiles (docs/releasing.md, "App Store Connect API key"). Until
-# that key is replaced, a build reaches TestFlight only when someone runs this.
+# Prefer the Release workflow when secrets are set: it archives with
+# --manual-signing (Distribution + named App Store profiles). This script is
+# the laptop path when you want the signed-in Xcode account to manage profiles.
 #
 # Signing here comes from the Xcode account on this Mac, which already has the
 # Apple Distribution certificate. So the ASC key is deliberately kept out of


### PR DESCRIPTION
## Summary
- The 1.2.0 TestFlight job failed because the **archive** still used Automatic signing + the ASC API key, which mints iOS Development certificates until the team hits Apple's cap (`Choose a certificate to revoke`).
- `--manual-signing` now signs the archive the same way as export (Distribution + named App Store profiles) and only uses the API key for `asc` upload.

## Test plan
- [ ] Merge, then `gh workflow run release.yml -f upload_testflight=true -f notarize=false` (or with notarize if you want)
- [ ] Confirm iOS → TestFlight archives without Development profile errors
- [ ] Optional cleanup: revoke leftover `Created via API` development certs in Apple Developer


Made with [Cursor](https://cursor.com)