### PR TITLE
fix(ci): embed the iCloud profile in released macOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,46 @@ jobs:
           echo "imported=true" >> "$GITHUB_OUTPUT"
           echo "Using identity: $IDENTITY"
 
+      # Multi-Mac over CloudKit rides on restricted `com.apple.developer.*`
+      # entitlements, which build-app.sh merges only when a Developer ID
+      # profile authorizes them (see docs/multi-mac.md). Without this step the
+      # release notarizes and downloads fine, and every Mac that opens it finds
+      # iCloud off — which is what shipped through 1.2.0.
+      #
+      # Soft-falls back like the certificate above: no secret means the artifact
+      # is exactly the one that shipped before multi-Mac existed, minus the
+      # feature. Stamping the keys on without the profile would be far worse
+      # than shipping without them, because the app is then killed at launch.
+      - name: Install iCloud provisioning profile
+        id: profile
+        if: steps.cert.outputs.imported == 'true'
+        env:
+          MACOS_PROVISION_PROFILE: ${{ secrets.MACOS_PROVISION_PROFILE }}
+        run: |
+          if [[ -z "${MACOS_PROVISION_PROFILE:-}" ]]; then
+            echo "::warning::No MACOS_PROVISION_PROFILE — multi-Mac CloudKit is off in this build (see docs/multi-mac.md)."
+            exit 0
+          fi
+          PROFILE_PATH="$RUNNER_TEMP/headroom.provisionprofile"
+          echo -n "$MACOS_PROVISION_PROFILE" | base64 --decode > "$PROFILE_PATH"
+
+          # A profile that does not decode, or that names another team than the
+          # certificate, produces an app that signs and notarizes and is then
+          # killed on launch. Fail here, where the log still says why.
+          if ! PLIST="$(security cms -D -i "$PROFILE_PATH" 2>/dev/null)"; then
+            echo "error: MACOS_PROVISION_PROFILE did not decode to a provisioning profile" >&2
+            exit 1
+          fi
+          PROFILE_TEAM="$(plutil -extract TeamIdentifier.0 raw -o - - <<<"$PLIST" 2>/dev/null || true)"
+          CERT_TEAM="$(sed -n 's/.*(\([A-Z0-9]\{10\}\))$/\1/p' <<<"${HEADROOM_SIGN_IDENTITY:-}")"
+          if [[ -n "$CERT_TEAM" && -n "$PROFILE_TEAM" && "$PROFILE_TEAM" != "$CERT_TEAM" ]]; then
+            echo "error: profile team $PROFILE_TEAM does not match signing identity team $CERT_TEAM" >&2
+            exit 1
+          fi
+
+          echo "HEADROOM_PROVISION_PROFILE=$PROFILE_PATH" >> "$GITHUB_ENV"
+          echo "Profile installed (team ${PROFILE_TEAM:-unknown}) — multi-Mac CloudKit will be on."
+
       - name: Build + notarize
         id: notarize
         if: steps.cert.outputs.imported == 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,6 +252,12 @@ Four rules are load-bearing if you touch it:
   `Headroom-iCloud.entitlements` is merged in by `scripts/build-app.sh` only
   when `HEADROOM_PROVISION_PROFILE` supplies one. No profile, no keys, and the
   artifact matches what shipped before the feature.
+- **In CI that profile comes from the `MACOS_PROVISION_PROFILE` secret**, and
+  its absence is invisible in a green run. Through 1.2.0 the workflow never set
+  the variable, so every published release was notarized and had iCloud off.
+  Grep the build log for `multi-Mac CloudKit is off` before believing a release
+  can sync. Entitlements are sealed into a signature, so an already-downloaded
+  app never gains CloudKit — it takes a new release.
 - **The merge stays in Python.** `MachineCloudSync.swift` carries bytes and
   holds no opinion about them. A second implementation of last-writer-wins
   would drift, and the symptom would be settings quietly reverting on one Mac.

--- a/docs/multi-mac.md
+++ b/docs/multi-mac.md
@@ -51,10 +51,14 @@ Turning it **off** stops this Mac publishing. It does not delete the record:
 the other Macs are still reading it, and reaching into iCloud to remove
 something on their behalf is not what a local toggle should mean.
 
-**It needs a signed build.** CloudKit answers entitlements, and entitlements
-need a provisioning profile, so a local `CODE_SIGNING_ALLOWED=NO` build
-compiles the code but cannot reach the container. Settings says so on a build
-that cannot, rather than leaving the toggle looking broken.
+**It needs a build signed with the iCloud profile.** CloudKit answers
+entitlements, and entitlements need a provisioning profile to authorize them,
+so a local `CODE_SIGNING_ALLOWED=NO` build compiles the code but cannot reach
+the container. Neither can a notarized release built without the profile, which
+is a different problem with the same symptom. Settings distinguishes them:
+`MachineCloudSync.isDeveloperIDSigned` separates "you built this yourself" from
+"this release shipped without the profile", because only the first is fixed by
+downloading a release.
 
 ## Turning it on for the first time, once
 
@@ -67,8 +71,26 @@ Three manual steps, none of which anything here can do for you:
    it.
 3. **Point the build at it**: `HEADROOM_PROVISION_PROFILE=/path/to.profile`.
    `scripts/build-app.sh` then copies it to `Contents/embedded.provisionprofile`
-   and merges `Headroom-iCloud.entitlements` into the signature. For releases,
-   the workflow needs the profile as a secret and that variable set.
+   and merges `Headroom-iCloud.entitlements` into the signature.
+4. **For releases, set the `MACOS_PROVISION_PROFILE` secret** to the base64 of
+   that same file. `scripts/setup-release-secrets.sh --provision-profile` does
+   it. The release workflow decodes it, checks its team against the signing
+   certificate, and exports `HEADROOM_PROVISION_PROFILE` before
+   `scripts/build-app.sh`.
+
+Step 4 is not optional in practice and was missing until 1.2.0, which is why
+every release up to and including that one was notarized, installable, and had
+iCloud off. Nothing was red. `codesign -d --entitlements -` on the downloaded
+app showed the app group and nothing else, and the build log said
+`no HEADROOM_PROVISION_PROFILE`. **A previously downloaded copy never gains
+CloudKit** — entitlements are sealed into a signature, so it takes a new
+release.
+
+To check any copy of the app:
+
+```bash
+codesign -d --entitlements - --xml /Applications/Headroom.app | plutil -convert xml1 -o - -
+```
 
 Without step 3 the build signs exactly as it did before multi-Mac existed. That
 is deliberate — see below.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -207,6 +207,22 @@ if the team is already at its cap.
 | `APPLE_API_ISSUER_ID` | Issuer ID |
 | `ASC_APP_ID` | App Store Connect app id (`6795549853`) |
 | `ASC_TESTFLIGHT_GROUP` | Optional; default `Internal` |
+| `MACOS_PROVISION_PROFILE` | Optional; base64 of the **Developer ID** `.provisionprofile` for `com.centaur-labs.headroom.macos` with iCloud. Turns multi-Mac CloudKit on. |
+
+`MACOS_PROVISION_PROFILE` is the one secret whose absence is invisible in a
+green run. The release notarizes and publishes exactly as it always did, and
+the app it ships reports multi-Mac over iCloud as unavailable on every Mac that
+opens it. That is what happened through 1.2.0. The tell is in the build log:
+
+```
+note: no HEADROOM_PROVISION_PROFILE — multi-Mac CloudKit is off in this build
+```
+
+With the secret set, the same line reads `note: embedded … — multi-Mac CloudKit
+is on`. It is deliberately a warning and not a failure, because the alternative
+is worse: stamping the restricted iCloud entitlements on with no profile to
+authorize them produces an app that signs, notarizes, downloads, and is killed
+the moment it launches. See [multi-mac.md](multi-mac.md).
 
 Helper (needs a `gh` token that can write Actions secrets):
 

--- a/macos/Sources/MachineCloudSync.swift
+++ b/macos/Sources/MachineCloudSync.swift
@@ -52,6 +52,34 @@ final class MachineCloudSync {
         return value != nil
     }()
 
+    /// Whether this binary carries a Developer ID signature.
+    ///
+    /// Only ever used to explain *why* iCloud is off, and it exists because
+    /// "signed releases can" was a lie for every release up to 1.2.0: the
+    /// workflow notarized without `HEADROOM_PROVISION_PROFILE`, so a download
+    /// from GitHub was signed, notarized, and still carried no iCloud
+    /// entitlement. Telling its owner to go and get a signed release is the one
+    /// answer guaranteed to waste their time.
+    ///
+    /// Signed but unavailable means the profile was missing at build time.
+    /// Unsigned means a local build, where it can never be anything else.
+    static let isDeveloperIDSigned: Bool = {
+        var code: SecStaticCode?
+        guard SecStaticCodeCreateWithPath(
+                Bundle.main.bundleURL as CFURL, [], &code) == errSecSuccess,
+              let code else { return false }
+        var info: CFDictionary?
+        guard SecCodeCopySigningInformation(
+                code, SecCSFlags(rawValue: kSecCSSigningInformation), &info) == errSecSuccess,
+              let dict = info as? [String: Any],
+              let certs = dict[kSecCodeInfoCertificates as String] as? [SecCertificate],
+              let leaf = certs.first else { return false }
+        var name: CFString?
+        guard SecCertificateCopyCommonName(leaf, &name) == errSecSuccess,
+              let common = name as String? else { return false }
+        return common.hasPrefix("Developer ID Application:")
+    }()
+
     private let database: CKDatabase
     private let endpoint: String
     private var subscribed = false

--- a/macos/Sources/Settings/SettingsView.swift
+++ b/macos/Sources/Settings/SettingsView.swift
@@ -318,9 +318,19 @@ struct SettingsView: View {
                         // Only this side can know: the host has no idea how the
                         // app was signed. A development build silently doing
                         // nothing here is the most confusing outcome available.
+                        //
+                        // Two different reasons, and they need different
+                        // answers. A notarized release with no iCloud profile
+                        // is not something its owner can fix by downloading
+                        // another copy of what they already have, which is
+                        // exactly what the old wording sent them off to do.
                         Label(
-                            "This build of Headroom cannot use iCloud. "
-                            + "Signed releases can.",
+                            MachineCloudSync.isDeveloperIDSigned
+                            ? "This release was built without the iCloud "
+                                + "profile, so multi-Mac sync is off."
+                            : "Local builds cannot use iCloud. A notarized "
+                                + "release carries the profile that turns "
+                                + "multi-Mac sync on.",
                             systemImage: "exclamationmark.triangle"
                         )
                         .font(.caption)

--- a/scripts/setup-release-secrets.sh
+++ b/scripts/setup-release-secrets.sh
@@ -15,6 +15,10 @@
 #     --api-issuer-id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 #
 # Optional: --keychain-password 'random'  (defaults to a generated value)
+# Optional: --provision-profile ~/Desktop/Headroom.provisionprofile
+#           Developer ID profile for com.centaur-labs.headroom.macos with the
+#           iCloud capability. Without it releases build fine and multi-Mac
+#           over CloudKit is off in them (docs/multi-mac.md).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -26,6 +30,7 @@ API_KEY=""
 API_KEY_ID=""
 API_ISSUER_ID=""
 KEYCHAIN_PASSWORD=""
+PROVISION_PROFILE=""
 
 die() { echo "error: $*" >&2; exit 1; }
 
@@ -37,8 +42,9 @@ while [[ $# -gt 0 ]]; do
     --api-key-id) API_KEY_ID="${2:-}"; shift 2 ;;
     --api-issuer-id) API_ISSUER_ID="${2:-}"; shift 2 ;;
     --keychain-password) KEYCHAIN_PASSWORD="${2:-}"; shift 2 ;;
+    --provision-profile) PROVISION_PROFILE="${2:-}"; shift 2 ;;
     -h|--help)
-      sed -n '2,20p' "$0"
+      sed -n '2,24p' "$0"
       exit 0
       ;;
     *) die "unknown argument: $1" ;;
@@ -65,6 +71,20 @@ printf '%s' "$KEYCHAIN_PASSWORD" | gh secret set KEYCHAIN_PASSWORD --repo "$REPO
 gh secret set APPLE_API_KEY --repo "$REPO" < "$API_KEY"
 printf '%s' "$API_KEY_ID" | gh secret set APPLE_API_KEY_ID --repo "$REPO"
 printf '%s' "$API_ISSUER_ID" | gh secret set APPLE_API_ISSUER_ID --repo "$REPO"
+
+# Optional, and the release still works without it. Skipping only means the
+# published app has no iCloud entitlement, so multi-Mac reports itself off.
+# Merging those entitlements with no profile to authorize them would be the
+# genuinely bad outcome: the app signs, notarizes, and dies at launch.
+if [[ -n "$PROVISION_PROFILE" ]]; then
+  [[ -f "$PROVISION_PROFILE" ]] || die "--provision-profile $PROVISION_PROFILE not found"
+  security cms -D -i "$PROVISION_PROFILE" >/dev/null 2>&1 \
+    || die "--provision-profile is not a provisioning profile"
+  base64 < "$PROVISION_PROFILE" | gh secret set MACOS_PROVISION_PROFILE --repo "$REPO"
+  echo "Set MACOS_PROVISION_PROFILE — multi-Mac CloudKit will be on from the next release."
+else
+  echo "No --provision-profile — multi-Mac CloudKit stays off in releases (docs/multi-mac.md)."
+fi
 
 echo
 echo "Done. Verify with: gh secret list --repo $REPO"


### PR DESCRIPTION
## The bug

Every release through 1.2.0 was notarized with no `HEADROOM_PROVISION_PROFILE`
set, so `build-app.sh` skipped the `Headroom-iCloud.entitlements` merge and
published an app whose signature carried only the app group.

Proven on the shipped `v1.2.0` asset, not inferred:

| Check | Result |
|---|---|
| `Contents/embedded.provisionprofile` | absent |
| entitlements | `com.apple.security.application-groups` only |
| identity | `Developer ID Application: CENTAUR LABS OU (992N457T8D)` |
| `spctl` | `accepted / Notarized Developer ID` |

So the release was genuinely signed and notarized and had iCloud off.
`MachineCloudSync.isAvailable` was false, correctly. The build log said so and
the release went out green:

```
note: no HEADROOM_PROVISION_PROFILE — multi-Mac CloudKit is off in this build
```

The gap was missing CI wiring *and* a missing secret. The CloudKit container
existed on the team the whole time.

## What changed

- **`release.yml`** — new "Install iCloud provisioning profile" step. Decodes
  `MACOS_PROVISION_PROFILE`, rejects a profile whose team does not match the
  signing certificate, exports the variable before `build-app.sh`. A missing
  secret warns and continues, matching the certificate fallback above it.
  Stamping the restricted entitlements on with no profile to authorize them
  ships an app that signs, notarizes, downloads and is killed at launch, which
  is worse than shipping without the feature.
- **`setup-release-secrets.sh`** — optional `--provision-profile`.
- **`MachineCloudSync.swift`** — `isDeveloperIDSigned`.
- **`SettingsView.swift`** — Settings said *"This build of Headroom cannot use
  iCloud. Signed releases can."* That was false for exactly the people most
  likely to read it, and sent them to download another copy of what they
  already had. Now split on `isDeveloperIDSigned`.
- **`multi-mac.md`, `releasing.md`, `AGENTS.md`** — document the secret and the
  fact that its absence is invisible in a green run.

## Verifying

`MACOS_PROVISION_PROFILE` is set, from a Developer ID profile verified as
`ProvisionsAllDevices: true`, container `iCloud.com.centaur-labs.headroom`,
team 992N457T8D.

The next release's build log should read `multi-Mac CloudKit is on`, and on the
downloaded app:

```bash
codesign -d --entitlements - --xml /Applications/Headroom.app | plutil -convert xml1 -o - -
```

should list `com.apple.developer.icloud-services`.

**An already-downloaded copy never gains CloudKit** — entitlements are sealed
into a signature, so this takes a new release.

## Notes

- No `host/VERSION` bump. Land the fix, ship separately.
- `xcodebuild test` is 41/41 green on `main` as of #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)