### PR TITLE
fix(multi-mac): deploy the CloudKit schema, and say when it is missing

### DIFF
--- a/docs/multi-mac.md
+++ b/docs/multi-mac.md
@@ -62,7 +62,7 @@ downloading a release.
 
 ## Turning it on for the first time, once
 
-Three manual steps, none of which anything here can do for you:
+Five manual steps, none of which anything here can do for you:
 
 1. **Create the CloudKit container** `iCloud.com.centaur-labs.headroom` in the
    Apple Developer portal, under the same team that signs the app.
@@ -77,6 +77,21 @@ Three manual steps, none of which anything here can do for you:
    it. The release workflow decodes it, checks its team against the signing
    certificate, and exports `HEADROOM_PROVISION_PROFILE` before
    `scripts/build-app.sh`.
+5. **Deploy the CloudKit schema to Production.** Import
+   [`macos/Headroom-CloudKit.ckdb`](../macos/Headroom-CloudKit.ckdb) in the
+   CloudKit Console (**Import Schema…**), then **Deploy Schema Changes…**
+   from Development to Production.
+
+Step 5 looks optional and is not. A Developer ID build is pinned to the
+**Production** environment by its profile
+(`com.apple.developer.icloud-container-environment`), and CloudKit only
+auto-creates record types in **Development**. A container whose Production
+schema has no `Machine` type fails every save and every query — which is
+exactly what 1.2.1 shipped into. iCloud was correctly entitled, the amber
+banner was gone, both Macs said "No other Macs yet", and nothing anywhere said
+why. The schema file is the source of truth for what the container holds:
+changing what `MachineCloudSync` writes means changing it and redeploying, or
+the write fails in Production while a development build still works.
 
 Step 4 is not optional in practice and was missing until 1.2.0, which is why
 every release up to and including that one was notarized, installable, and had

--- a/macos/Headroom-CloudKit.ckdb
+++ b/macos/Headroom-CloudKit.ckdb
@@ -1,0 +1,27 @@
+DEFINE SCHEMA
+
+    RECORD TYPE Machine (
+        "___createTime" TIMESTAMP,
+        "___createdBy"  REFERENCE,
+        "___etag"       STRING,
+        "___modTime"    TIMESTAMP QUERYABLE SORTABLE,
+        "___modifiedBy" REFERENCE,
+        "___recordID"   REFERENCE QUERYABLE,
+        payload         STRING,
+        updated         TIMESTAMP,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_creator"
+    );
+
+    RECORD TYPE Users (
+        "___createTime" TIMESTAMP,
+        "___createdBy"  REFERENCE,
+        "___etag"       STRING,
+        "___modTime"    TIMESTAMP,
+        "___modifiedBy" REFERENCE,
+        "___recordID"   REFERENCE,
+        roles           LIST<INT64>,
+        GRANT WRITE TO "_creator",
+        GRANT READ TO "_world"
+    );

--- a/macos/Sources/MachineCloudSync.swift
+++ b/macos/Sources/MachineCloudSync.swift
@@ -105,10 +105,42 @@ final class MachineCloudSync {
             let peers = try await fetchPeers()
             let round = try await client.syncMachines(records: peers)
             try await save(id: round.recordID, payload: round.recordJSON)
+            Self.lastFailure = nil
             return .success(MultiMacRoundSummary(
                 peers: round.peerCount, adopted: round.adopted.count))
         } catch {
+            Self.lastFailure = Self.describe(error)
             return .failure(error)
+        }
+    }
+
+    /// Why the last round failed, or nil when the last one worked.
+    ///
+    /// This exists because the failure had nowhere to go. `trouble_detail`
+    /// comes from the host and describes the *folder* transport, so a CloudKit
+    /// error fell through to "No other Macs yet" — the same words a working
+    /// sync with nobody else on it produces. 1.2.1 shipped with no `Machine`
+    /// record type in the Production container, and both Macs sat there
+    /// reporting that reassuring nothing while every save failed.
+    static private(set) var lastFailure: String?
+
+    /// CloudKit's own message, with the cases worth naming spelled out.
+    /// A missing record type is a deployment mistake rather than a runtime
+    /// fault, and nothing in the raw error says where to go and fix it.
+    private static func describe(_ error: Error) -> String {
+        guard let ck = error as? CKError else { return error.localizedDescription }
+        switch ck.code {
+        case .unknownItem, .invalidArguments:
+            return "iCloud is missing the Machine record type. Deploy the "
+                + "CloudKit schema to Production — see docs/multi-mac.md."
+        case .notAuthenticated:
+            return "Sign in to iCloud on this Mac to share settings between Macs."
+        case .networkUnavailable, .networkFailure, .serviceUnavailable:
+            return "iCloud is unreachable right now. Retrying."
+        case .quotaExceeded:
+            return "This iCloud account is out of storage."
+        default:
+            return ck.localizedDescription
         }
     }
 

--- a/macos/Sources/Settings/SettingsView.swift
+++ b/macos/Sources/Settings/SettingsView.swift
@@ -335,6 +335,15 @@ struct SettingsView: View {
                         )
                         .font(.caption)
                         .foregroundStyle(HeadroomPalette.amber)
+                    } else if let failure = MachineCloudSync.lastFailure {
+                        // Ahead of the host's trouble_detail because that field
+                        // only ever describes the folder transport. A CloudKit
+                        // round that threw used to fall all the way through to
+                        // "No other Macs yet", which reads as a working sync
+                        // that nobody else has joined.
+                        Label(failure, systemImage: "exclamationmark.triangle")
+                            .font(.caption)
+                            .foregroundStyle(HeadroomPalette.amber)
                     } else if let detail = multiMac.troubleDetail {
                         Label(detail, systemImage: "exclamationmark.triangle")
                             .font(.caption)


### PR DESCRIPTION
## The bug

1.2.1 entitled the app for iCloud correctly — `isAvailable` true, amber banner
gone — and multi-Mac still did nothing. Both Macs showed "No other Macs yet".

The container has no `Machine` record type in **Production**, so every save and
every query fails. CloudKit auto-creates record types only in **Development**,
and a Developer ID build is pinned to Production by its profile
(`com.apple.developer.icloud-container-environment`). Nothing had ever created
the type in either environment — until today no build could reach CloudKit at
all, so nothing ever wrote a record.

Confirmed by exporting the container's Development schema: it contains only the
stock `Users` type.

## Why it was invisible

`cloudRound()` matched only `.success`:

```swift
if case let .success(summary) = await sync.run(), summary.adopted > 0 {
```

The `.failure` branch was never handled — not logged, not stored, not shown.
And `trouble_detail` comes from the host and describes the *folder* transport,
so a CloudKit error fell through to "No other Macs yet", which is what a
healthy sync with nobody else on it says. Every failure mode rendered as
success.

## What changed

- **`macos/Headroom-CloudKit.ckdb`** — the schema as a reviewable file rather
  than state in Apple's web console. `___recordID` stays `QUERYABLE` because
  `fetchPeers()` and the `machine-changes` subscription both use
  `NSPredicate(value: true)`, which CloudKit refuses without that index. Grants
  are `_creator`; this is the private database, so `_world` would claim more
  than is true.
- **`MachineCloudSync.lastFailure`** — set on a failed round, cleared on a good
  one. `describe(_:)` names a missing record type as a deployment mistake and
  points at the doc, rather than repeating CloudKit's own wording.
- **`SettingsView`** — shows it, ahead of the host's `trouble_detail`.
- **`docs/multi-mac.md`** — schema deployment added as step 5, with why it
  looks optional and is not.

## Verifying

Import the `.ckdb` in CloudKit Console, then **Deploy Schema Changes** to
Production. The schema is server-side, so an already-installed 1.2.1 picks it
up on its next round (120s) with no new build.

`xcodebuild test` 41/41 green.

## Notes

- No `host/VERSION` bump. The schema deployment is what unblocks sync; the
  error-surfacing is worth shipping but not urgent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)