### PR TITLE
fix(build): carry the profile's application identity into the signature

### DIFF
--- a/docs/multi-mac.md
+++ b/docs/multi-mac.md
@@ -107,6 +107,22 @@ To check any copy of the app:
 codesign -d --entitlements - --xml /Applications/Headroom.app | plutil -convert xml1 -o - -
 ```
 
+That output must carry **five** keys, not three. Alongside the two iCloud keys
+and the app group it needs `com.apple.application-identifier`,
+`com.apple.developer.team-identifier` and
+`com.apple.developer.icloud-container-environment`. Xcode copies those out of
+the profile when it signs; `codesign` does not, because it stamps exactly what
+the entitlements plist holds. `scripts/build-app.sh` reads them off the
+embedded profile instead, so they can never disagree with the profile that
+authorizes them.
+
+Without them the container has no application identity to bind to, and
+CloudKit fails with **"Trying to initialize a container without an application
+ID"**. 1.2.2 shipped in that state: profile embedded, iCloud entitlements
+present, `MachineCloudSync.isAvailable` true, Settings showing no warning, and
+not one record ever written. Three keys present is the failure that looks like
+success.
+
 Without step 3 the build signs exactly as it did before multi-Mac existed. That
 is deliberate — see below.
 

--- a/macos/Sources/MachineCloudSync.swift
+++ b/macos/Sources/MachineCloudSync.swift
@@ -124,24 +124,32 @@ final class MachineCloudSync {
     /// reporting that reassuring nothing while every save failed.
     static private(set) var lastFailure: String?
 
-    /// CloudKit's own message, with the cases worth naming spelled out.
-    /// A missing record type is a deployment mistake rather than a runtime
-    /// fault, and nothing in the raw error says where to go and fix it.
+    /// CloudKit's own message, with a hint appended where one is worth having.
+    ///
+    /// The hint is never allowed to *replace* what CloudKit said. An earlier
+    /// version mapped `.invalidArguments` straight to "deploy the schema",
+    /// which would have buried the message that actually solved this —
+    /// "Trying to initialize a container without an application ID", a signing
+    /// problem with nothing to do with the schema. A guess that hides the
+    /// evidence is worse than no guess.
     private static func describe(_ error: Error) -> String {
         guard let ck = error as? CKError else { return error.localizedDescription }
+        let hint: String?
         switch ck.code {
         case .unknownItem, .invalidArguments:
-            return "iCloud is missing the Machine record type. Deploy the "
-                + "CloudKit schema to Production — see docs/multi-mac.md."
+            hint = "If iCloud is missing the Machine record type, deploy the "
+                + "CloudKit schema to Production (docs/multi-mac.md)."
         case .notAuthenticated:
-            return "Sign in to iCloud on this Mac to share settings between Macs."
+            hint = "Sign in to iCloud on this Mac to share settings between Macs."
         case .networkUnavailable, .networkFailure, .serviceUnavailable:
-            return "iCloud is unreachable right now. Retrying."
+            hint = "Retrying."
         case .quotaExceeded:
-            return "This iCloud account is out of storage."
+            hint = "This iCloud account is out of storage."
         default:
-            return ck.localizedDescription
+            hint = nil
         }
+        guard let hint else { return ck.localizedDescription }
+        return "\(ck.localizedDescription) \(hint)"
     }
 
     /// Payload strings exactly as stored. Never parsed on this side.

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -145,6 +145,44 @@ embed_icloud_profile() {
   cp "$profile" "$APP/Contents/embedded.provisionprofile"
   /usr/libexec/PlistBuddy -c "Merge $ROOT/macos/Headroom-iCloud.entitlements" \
     "$app_ents" >/dev/null
+
+  # Xcode copies these three out of the profile when it signs. codesign does
+  # not — it stamps exactly what the plist holds and nothing else — so a
+  # hand-signed bundle carries the container identifier with no application
+  # identity to bind it to. CloudKit's answer to that is
+  #
+  #   "Trying to initialize a container without an application ID"
+  #
+  # which names the missing key without saying where it should have come from.
+  # 1.2.2 shipped exactly that way: entitled for iCloud by every check we had,
+  # and unable to open the container on any Mac.
+  #
+  # Read them off the profile rather than hardcoding, so they cannot disagree
+  # with the profile that authorizes them. The environment matters as much as
+  # the identifier — a Developer ID profile is Production, and without the key
+  # CloudKit has nothing telling it which side of the container to talk to.
+  local decoded value
+  decoded="$(mktemp -t headroom-profile)"
+  if ! security cms -D -i "$profile" > "$decoded" 2>/dev/null; then
+    echo "error: $profile is not a readable provisioning profile" >&2
+    rm -f "$decoded"
+    exit 1
+  fi
+  for key in com.apple.application-identifier \
+             com.apple.developer.team-identifier \
+             com.apple.developer.icloud-container-environment; do
+    value="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:$key" "$decoded" \
+      2>/dev/null || true)"
+    if [[ -z "$value" ]]; then
+      echo "error: profile carries no $key — it cannot authorize CloudKit" >&2
+      rm -f "$decoded"
+      exit 1
+    fi
+    /usr/libexec/PlistBuddy -c "Delete :$key" "$app_ents" >/dev/null 2>&1 || true
+    /usr/libexec/PlistBuddy -c "Add :$key string $value" "$app_ents" >/dev/null
+  done
+  rm -f "$decoded"
+
   echo "note: embedded $(basename "$profile") — multi-Mac CloudKit is on" >&2
 }
 


### PR DESCRIPTION
## The bug

1.2.2 surfaced the real CloudKit error for the first time, and it was not the
schema:

> Trying to initialize a container without an application ID

The signature carried three keys. It needs five.

| Key | In the profile | In shipped 1.2.2 |
|---|---|---|
| `com.apple.developer.icloud-container-identifiers` | ✅ | ✅ |
| `com.apple.developer.icloud-services` | ✅ | ✅ |
| `com.apple.security.application-groups` | — | ✅ |
| `com.apple.application-identifier` | ✅ | ❌ |
| `com.apple.developer.team-identifier` | ✅ | ❌ |
| `com.apple.developer.icloud-container-environment` | ✅ | ❌ |

Xcode copies those three out of the provisioning profile when it signs.
`codesign` does not — it stamps exactly what the entitlements plist holds. So
the bundle declared a container it had no application identity to bind to.

1.2.2 was entitled for iCloud by every check available: profile embedded,
`icloud-services` present, `isAvailable` true, no warning in Settings, and not
one record ever written on either Mac.

## What changed

- **`scripts/build-app.sh`** — `embed_icloud_profile` reads the three keys off
  the embedded profile and merges them in. Read rather than hardcoded so they
  cannot disagree with the profile that authorizes them; a profile missing any
  of them now fails the build instead of shipping another app that cannot open
  its container.
- **`MachineCloudSync.describe`** — stop replacing CloudKit's message with our
  hint. It mapped `.invalidArguments` straight to "deploy the schema", which
  would have buried the message that actually solved this. Hints are appended,
  never substituted.
- **`docs/multi-mac.md`** — the five-key check, and why three looks like
  success.

## Verifying

Simulated the full merge against the real embedded profile; the result is the
entitlement set a correctly signed CloudKit app carries:

```
com.apple.application-identifier              992N457T8D.com.centaur-labs.headroom.macos
com.apple.developer.icloud-container-environment  Production
com.apple.developer.icloud-container-identifiers  iCloud.com.centaur-labs.headroom
com.apple.developer.icloud-services               CloudKit
com.apple.developer.team-identifier               992N457T8D
com.apple.security.application-groups             992N457T8D.group.com.centaur-labs.headroom
```

`xcodebuild test` 41/41 green. The real proof is the next release's artifact
carrying five keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)