### PR TITLE
feat: say Needs sign-in when a credential dies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,11 @@ Ring and pace semantics are a cross-platform contract: `docs/rings.md`, with
 `Shared/HeadroomRings.swift` as the implementation and the firmware mirroring
 its constants. Changing one means changing all of them.
 
+Attention rollup scoring is the same kind of contract: `docs/attention.md`.
+Weights and ages stay hardcoded product policy — do not add an Attention
+Settings pane. Gateway prefs live under Coding agents; see
+`docs/agent-attention.md`.
+
 ## Multi-Mac
 
 Settings sync between Macs over CloudKit, one record per machine, written by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ are not tracked here because they move on every commit.
 Add a section here before cutting a tag. `scripts/cut-release.sh` refuses to
 tag a version that has no entry.
 
+## 1.2.4 — 2026-07-30
+
+### Added
+
+- `scripts/update-app.sh` installs the latest notarized Release from the
+  command line. This landed on `main` ahead of the bump and ships here rather
+  than in a release of its own.
+
+### Changed
+
+- iOS Overview **Connected** tile names the Mac and its address (Computer
+  Name · host / IP), not just the last update time. Settings → Connection
+  shows the same split.
+- Watch Overall burndown lines are fully opaque, matching the ESP32 glance.
+  The binding source stays thicker; context sources no longer fade.
+- Mac Settings moves the Dashboard row limits out of General and in beside the
+  integrations whose rows they count.
+- `docs/attention.md` writes down what Attention scoring is: hardcoded product
+  policy, deliberately not a Settings pane. The README and CONTRIBUTING build
+  instructions also stop being wrong about XcodeGen being optional and about
+  `-sdk iphonesimulator` on the iPhone target.
+
+### Fixed
+
+- A source whose login has gone now says **Needs sign-in** instead of **Not
+  updating**, and says it on the card, in Settings, and in Attention. The host
+  ships `auth_required` next to `stale`, so a dead credential is no longer
+  indistinguishable from a rate limit or a dropped network.
+- Quota cards show the host's error whenever there is one. The message was
+  gated on `ok`, which the host deliberately keeps true while it replays the
+  last good bars — so the failures that had a reason worth reading were exactly
+  the ones that hid it. A missing Claude token reported eleven hours of frozen
+  numbers without ever surfacing the `claude login` it was asking for.
+- Attention calls out a missing login immediately rather than waiting out the
+  fifteen-minute stale threshold. Waiting does not fix a login.
+- The ESP32 corner glyph marks a frozen reading, not just a dropped cable. It
+  was gated on whether the Mac answered, so the case that lasts — the Mac
+  replying every ten seconds about numbers it has been unable to refresh since
+  last night — drew nothing at all. Ages now read `42m` / `11h` / `3d`, and a
+  dead login is prefixed `!`.
+
 ## 1.2.3 — 2026-07-30
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,13 +32,19 @@ cp firmware/src/config_example.h firmware/src/config.h && cd firmware && pio run
 ```
 
 ```bash
-./scripts/gen-project.sh && cd macos && xcodebuild -project Headroom.xcodeproj -scheme HeadroomMobile -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -configuration Debug CODE_SIGNING_ALLOWED=NO build
+./scripts/gen-project.sh && cd macos && xcodebuild -project Headroom.xcodeproj -scheme HeadroomMobile -destination 'generic/platform=iOS Simulator' -configuration Debug CODE_SIGNING_ALLOWED=NO build
 ```
+
+The iPhone app embeds the watch app, so that last one needs an Xcode whose
+watchOS SDK is actually installed — see
+[docs/ios-companion.md](docs/ios-companion.md). Do not add `-sdk
+iphonesimulator` to it.
 
 A full `.app`: `./scripts/build-app.sh` writes `dist/Headroom.app`, ad-hoc
 signed, no Apple account needed.
 
-CI runs all three on every PR. Keep it green.
+CI runs the host, firmware, and macOS test jobs on every PR; the iOS build is
+local-only. Keep it green.
 
 ## Signing
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ seven-day burndown the Mac, phone and medium widget show.
 | Python 3.9+ | Bundled host is **stdlib only** (system `/usr/bin/python3`) |
 | At least one AI coding tool | Claude, Codex, Cursor, Copilot, Gemini, Windsurf, JetBrains AI or Zed, already signed in locally |
 | Optional: iPhone / iPad (iOS 17+) | Same LAN or Tailscale as the Mac |
-| Optional: Xcode + [xcodegen](https://github.com/yonaskolb/XcodeGen) | Build from source / flash tooling |
+| To build from source: Xcode **and** [XcodeGen](https://github.com/yonaskolb/XcodeGen) | Not either/or — the `.xcodeproj` is generated, so `brew install xcodegen` is required, not optional |
 | Optional: PlatformIO | Only if you flash the ESP32 |
 
 No Headroom cloud account. Tokens stay on your Mac.
@@ -127,6 +127,44 @@ open .build/Build/Products/Debug/Headroom.app
 
 **Foreground try** (no login item): `./scripts/install-host.sh --foreground`  
 **Uninstall LaunchAgent:** `./scripts/uninstall-host.sh` (`--purge` wipes `~/.headroom`)
+
+### Opening the project in Xcode
+
+A fresh clone contains no `.xcodeproj`, and that is expected: `macos/project.yml`
+is the source of truth and XcodeGen writes the project from it, so the generated
+`macos/Headroom.xcodeproj` is gitignored. On a new Mac, write it first:
+
+```bash
+brew install xcodegen
+```
+
+```bash
+./scripts/gen-project.sh
+```
+
+```bash
+open macos/Headroom.xcodeproj
+```
+
+Go through the script rather than calling `xcodegen generate` yourself.
+`project.yml` lists `macos/host` as a source directory, and that folder is a
+gitignored copy of the host made by `sync-embedded-host.sh` — on a fresh clone
+bare xcodegen stops at a missing source directory, which does not point at the
+real cause. The script syncs first.
+
+Anything touching the watch app needs the beta toolchain, and that includes the
+iPhone app, which embeds it. Stable Xcode reports a watchOS SDK and still
+resolves every watch destination to *"watchOS 26.5 is not installed"*:
+
+```bash
+open -a /Applications/Xcode-beta.app macos/Headroom.xcodeproj
+```
+
+Regenerate after any pull that adds files. A new file under `Shared/` will not be
+in the project you generated last week, and the failure reads as a missing type
+rather than a stale project. **Quit Xcode before regenerating** — replacing the
+project underneath a running Xcode is what produces *"The project “Headroom” is
+not a valid property list"* on a file that is perfectly valid.
 
 ### Option C — iPhone
 
@@ -270,6 +308,9 @@ LAN with `"require_auth": false`, in `~/.headroom/config.json`.
 | Gatekeeper blocks .app | Prefer a [notarized Release](https://github.com/michellzappa/headroom/releases); otherwise right-click → Open. Signing setup: [docs/releasing.md](docs/releasing.md) |
 | Restart host | `launchctl kickstart -k gui/$(id -u)/com.centaur-labs.headroom` |
 | Build a fresh .app | `./scripts/build-app.sh` → `dist/Headroom.app` |
+| No `.xcodeproj` in the clone | Expected — it is generated. `./scripts/gen-project.sh`, then open it |
+| Xcode: **not a valid property list** | The project was regenerated while Xcode held it open. Quit Xcode and reopen; the file on disk is fine (`plutil -lint` it to confirm) |
+| Xcode: **watchOS 26.5 is not installed** | Stable Xcode; reopen with `/Applications/Xcode-beta.app` |
 
 ## What it tracks
 
@@ -397,8 +438,7 @@ cd firmware && pio run
 ```
 
 `gen-project.sh` writes `macos/Headroom.xcodeproj`, which is generated and
-gitignored. Calling `xcodegen generate` directly on a fresh clone fails on the
-missing `macos/host` copy.
+gitignored — see [Opening the project in Xcode](#opening-the-project-in-xcode).
 
 `host/test_contract.py` and `macos/Tests/ContractTests.swift` pin the `/usage`
 shape. CI runs host + firmware + macOS on push (`.github/workflows/ci.yml`).
@@ -428,6 +468,8 @@ the port.
 | [CHANGELOG.md](CHANGELOG.md) | What changed in each tagged version |
 | [docs/glossary.md](docs/glossary.md) | Shared chrome names |
 | [docs/rings.md](docs/rings.md) | Ring / pace semantics |
+| [docs/attention.md](docs/attention.md) | Attention rollup policy (not Settings) |
+| [docs/agent-attention.md](docs/agent-attention.md) | Coding-agent attention gateway |
 | [docs/backlog.md](docs/backlog.md) | What's queued and why |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Build, test, and PR expectations |
 | [SECURITY.md](SECURITY.md) | Threat model and how to report a hole |

--- a/Shared/HeadroomCopy.swift
+++ b/Shared/HeadroomCopy.swift
@@ -157,6 +157,17 @@ enum HeadroomCopy {
         "\(notUpdating) · \(ago(age))"
     }
 
+    /// A meter whose login is gone or refused. "Not updating" is true of this
+    /// too, and useless: it reads as a connection to wait out, when the fetch
+    /// will keep failing until someone signs in. The age still travels with
+    /// it, because how long the numbers have been fiction is the part that
+    /// decides whether this matters now.
+    static let needsSignIn = "Needs sign-in"
+
+    static func needsSignIn(age: TimeInterval) -> String {
+        "\(needsSignIn) · \(ago(age))"
+    }
+
     // MARK: Activity feed
 
     /// What a feed row's host status (`failure`, `ready`, `pushed`, …) is

--- a/Shared/HeadroomModels.swift
+++ b/Shared/HeadroomModels.swift
@@ -338,7 +338,8 @@ struct UsageSnapshot: Decodable, Sendable {
             resetCreditsExpiryLabel: resetCreditsExpiryLabel,
             costLabel: costLabel,
             headlinePoolID: info.headline,
-            staleNote: info.staleNote
+            statusNote: info.statusNote,
+            needsSignIn: info.needsSignIn
         )
     }
 
@@ -614,10 +615,14 @@ struct ProviderMeter: Sendable {
     var costLabel: String?
     /// Host registry headline pool id (`week`, `total`, …) for menu-bar tanks.
     var headlinePoolID: String?
-    /// Set when the host is replaying frozen numbers — see
-    /// `QuotaProviderInfo.staleNote`, which is where the wording is decided.
-    /// Nil on a provider that is fetching normally.
-    var staleNote: String?
+    /// Set when the host cannot refresh this meter — a dead login or frozen
+    /// numbers. See `QuotaProviderInfo.statusNote`, which is where the wording
+    /// is decided. Nil on a provider that is fetching normally.
+    var statusNote: String?
+    /// Whether `statusNote` is about a credential rather than a slow fetch.
+    /// Carried alongside the note so a card can lead with it without having
+    /// to parse prose back into a state.
+    var needsSignIn: Bool
 
     var knownProvider: UsageProvider? { UsageProvider(rawValue: id) }
 
@@ -636,7 +641,8 @@ struct ProviderMeter: Sendable {
         resetCreditsExpiryLabel: String? = nil,
         costLabel: String? = nil,
         headlinePoolID: String? = nil,
-        staleNote: String? = nil
+        statusNote: String? = nil,
+        needsSignIn: Bool = false
     ) {
         self.id = id
         self.title = title
@@ -652,7 +658,8 @@ struct ProviderMeter: Sendable {
         self.resetCreditsExpiryLabel = resetCreditsExpiryLabel
         self.costLabel = costLabel
         self.headlinePoolID = headlinePoolID
-        self.staleNote = staleNote
+        self.statusNote = statusNote
+        self.needsSignIn = needsSignIn
     }
 
     /// Compatibility for call sites still typed on the known-provider enum.
@@ -807,6 +814,11 @@ struct QuotaProviderInfo: Decodable, Identifiable, Sendable {
     /// Seconds since the numbers were actually fetched. Nil when the host
     /// predates the field or never managed a good fetch to date from.
     var staleForS: Double?
+    /// The credential behind this provider is missing or was rejected. Always
+    /// arrives with `stale`, and is the more useful of the two: staleness is
+    /// a symptom shared by rate limits and dropped networks, and only this one
+    /// names something the reader can go and do.
+    var authRequired: Bool?
     var plan: String?
     var error: String?
     var accent: String?
@@ -830,6 +842,7 @@ struct QuotaProviderInfo: Decodable, Identifiable, Sendable {
         ok: Bool? = nil,
         stale: Bool? = nil,
         staleForS: Double? = nil,
+        authRequired: Bool? = nil,
         plan: String? = nil,
         error: String? = nil,
         accent: String? = nil,
@@ -847,6 +860,7 @@ struct QuotaProviderInfo: Decodable, Identifiable, Sendable {
         self.ok = ok
         self.stale = stale
         self.staleForS = staleForS
+        self.authRequired = authRequired
         self.plan = plan
         self.error = error
         self.accent = accent
@@ -860,6 +874,7 @@ struct QuotaProviderInfo: Decodable, Identifiable, Sendable {
         case id, title, label, kind, rank, enabled, ok, plan, error, accent, stale
         case headline, pools
         case staleForS = "stale_for_s"
+        case authRequired = "auth_required"
         case accentDefault = "accent_default"
         case resetNoteURL = "reset_note_url"
     }
@@ -895,10 +910,26 @@ struct QuotaProviderInfo: Decodable, Identifiable, Sendable {
     /// provider looks wrong.
     var isStale: Bool { stale == true }
 
-    /// "Not updating · 2 hours ago", or nil when the provider is fetching
-    /// normally. One place decides what a frozen meter says, so the Mac and
-    /// the phone cannot word it differently.
-    var staleNote: String? {
+    /// The credential is gone or refused, and the meter will not recover on
+    /// its own. Checked ahead of `isStale` everywhere, because it is true of
+    /// a provider that never managed a first fetch either — where there are
+    /// no frozen numbers to be stale, only an empty card that owes the reader
+    /// a reason.
+    var needsSignIn: Bool { authRequired == true }
+
+    /// The numbers on this card cannot be read as current — frozen, or behind
+    /// a login that is no longer working. What drains a ring and ambers a
+    /// caption, since both failures make the arc a claim about the past.
+    var readingSuspect: Bool { needsSignIn || isStale }
+
+    /// "Needs sign-in · 2 hours ago", "Not updating · 2 hours ago", or nil
+    /// when the provider is fetching normally. One place decides what a meter
+    /// in trouble says, so the Mac and the phone cannot word it differently.
+    var statusNote: String? {
+        if needsSignIn {
+            guard let age = staleForS else { return HeadroomCopy.needsSignIn }
+            return HeadroomCopy.needsSignIn(age: age)
+        }
         guard isStale else { return nil }
         guard let age = staleForS else { return HeadroomCopy.notUpdating }
         return HeadroomCopy.notUpdating(age: age)
@@ -1310,14 +1341,21 @@ struct SyncSource: Decodable, Identifiable, Sendable {
     var enabled: Bool?
     var ok: Bool?
     var stale: Bool?
+    /// This row's credential needs re-authenticating. Settings sorts on it and
+    /// says so in words: a row that reads "not connected" invites you to check
+    /// a network, which is the wrong half of the problem.
+    var authRequired: Bool?
     var configured: Bool?
     var error: String?
     var detail: String?
     var ageS: Int?
 
+    var needsSignIn: Bool { authRequired == true }
+
     enum CodingKeys: String, CodingKey {
         case id, title, label, hint, kind, group, accent, enabled, ok, stale
         case configured, error, detail
+        case authRequired = "auth_required"
         case accentDefault = "accent_default"
         case ageS = "age_s"
     }

--- a/docs/agent-attention.md
+++ b/docs/agent-attention.md
@@ -4,6 +4,10 @@ Headroom's attention gateway turns provider callbacks into one durable feed.
 The feed is provider-neutral; each adapter declares what it can safely send
 back. Codex is the first adapter.
 
+This is the **gateway** layer (events ledger + adapters). The separate
+**rollup** Attention card / menu-bar pip is product policy, not Settings —
+see [`attention.md`](attention.md).
+
 ## What exists now
 
 - A SQLite attention ledger with compare-and-swap revisions, idempotency keys,

--- a/docs/attention.md
+++ b/docs/attention.md
@@ -1,0 +1,58 @@
+# Attention
+
+Attention is two products that share a word. Do not add a Settings pane for
+either one's scoring knobs.
+
+| Layer | What | Where it lives |
+|-------|------|----------------|
+| **Rollup** | Glance pip + Attention card (`ok` / `warn` / `critical`) | `_build_attention` in `host/headroom_server.py` (queued for `host/attention.py` in [`backlog.md`](backlog.md)) |
+| **Gateway** | Coding-agent approval / idle events | Ledger + adapters — [`agent-attention.md`](agent-attention.md) |
+
+## Rollup scoring is product policy
+
+Weights, ages, critical steps, and which kinds fire are intentional constants —
+same posture as rings ([`rings.md`](rings.md)): one shared glance, not per-user
+dials. Exposing them as Settings would teach people to mute the light until it
+means nothing.
+
+Policy that already lives next to the code (do not turn these into prefs):
+
+- Quota % never pages Attention — rings own that reading.
+- Supabase lints: ERROR only; WARN/INFO stay in the app without lighting the pip.
+- Stale quotas alert after `STALE_ALERT_S`, not on every timeout.
+- GitHub Actions failures age out; Codex spend/time events are the only quota
+  path into Attention.
+
+**Clear** dismisses the current fingerprint until reasons change. That is ack
+state (`attention_ack_fingerprint` in local config), not a preference, and it
+does not sync across Macs.
+
+## What is already configurable
+
+| Knob | Surface |
+|------|---------|
+| Codex attention gateway on/off + binary | Mac Settings → Coding agents |
+| Claude hooks install / test | Mac Settings → Coding agents |
+| Answer coding agents | Mac Settings → iPhone (`agents` permission, default off) |
+| Attention notifications | iOS Settings → iPhone (`@AppStorage`) |
+| Disable a source | Sources — stops that source's stale/derived reasons |
+
+No Settings destination named Attention. No user-editable weights, ages, or
+severity thresholds. Ack fingerprint and the event ledger stay off
+`SHARED_CONFIG_KEYS` / CloudKit.
+
+## Future escape hatch only
+
+If a specific kind becomes chronic noise in real use (stuck amber forever), add
+**mute-by-kind**: a local boolean map in `config.json`, same locality as
+`agent_gateway_enabled`, gated inside the scorer. Place the toggle next to the
+source that feeds it (Coding agents or Integrations) — still not a scoring UI.
+
+Do not invent threshold pickers, weight sliders, or a synced attention-prefs
+blob. Revisit only when mute-by-kind is clearly needed.
+
+## Structural extract
+
+Moving `_build_attention` into `host/attention.py` is a file split
+([`backlog.md`](backlog.md)), not a settings project. It keeps weights in one
+place so a later mute filter has a single gate.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -16,7 +16,8 @@ everything else, so it moves first.
 - `host/usage_doc.py` gets `_compute_doc`, `_flatten_*`, `_build_activity`,
   `_bodies`. This is the harder half: the flatteners reach into module state.
 - `host/attention.py` gets `_build_attention` and its weights. Self-contained
-  once the doc builder is out.
+  once the doc builder is out. File split only — scoring stays product policy
+  (`docs/attention.md`), not a Settings surface.
 - The poller and `main()` stay.
 
 `test_contract.py` passing unchanged is the whole acceptance test. Do it in

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -123,8 +123,16 @@ blank axis.
 | **All clear** | Healthy summary — host default, Attention card, and the Activity feed with nothing failing |
 | **Needs attention** | Warning fallback when a reason has no summary; counted as **N need attention** above the Activity feed |
 | **Collecting history** | Burndown empty / early verdict |
+| **Not updating** | The host is replaying a source's last good numbers; the age travels with it (**Not updating · 2 hours ago**) |
+| **Needs sign-in** | That source's credential is missing or was rejected — `auth_required` on `providers[]` / `sources[]`. Ages the same way |
 | **Clear** | Dismiss attention on every surface |
 | **Refresh all** | Force-sync every source |
+
+**Needs sign-in** outranks **Not updating** wherever both are true, which is
+most of the time — a dead login also freezes the numbers. Staleness is shared
+by rate limits and dropped networks and reads as something to wait out; only
+this one names a thing the reader can go and do. `QuotaProviderInfo.statusNote`
+picks between them so no surface has to.
 
 Do not use **All clear** for connection health — that word belongs on the
 Attention card. The Overview status row uses **Connected** / **Mac unavailable**.

--- a/docs/ios-companion.md
+++ b/docs/ios-companion.md
@@ -69,9 +69,24 @@ compile:
 ./scripts/gen-project.sh
 cd macos
 xcodebuild -project Headroom.xcodeproj -scheme HeadroomMobile \
-  -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' \
+  -destination 'generic/platform=iOS Simulator' \
   -configuration Debug CODE_SIGNING_ALLOWED=NO build
 ```
+
+Two things about that command, neither of which the error messages tell you.
+**It builds the watch app too** — `HeadroomMobile` embeds it — so
+the toolchain needs a watchOS SDK that resolves, not just one it reports. An
+Xcode that fails with *"watchOS 26.5 is not installed"* on a watch destination
+fails here as well; point `DEVELOPER_DIR` at one that works:
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+```
+
+And **do not add `-sdk iphonesimulator`.** It overrides the SDK for the embedded
+watch complication too, which then fails with *"'accessoryCorner' is unavailable
+in iOS"* — a red herring that has nothing to do with the complication code. The
+`-destination` above is sufficient on its own.
 
 **Physical phone.** Unlike the Mac app, this cannot be built unsigned, and the
 repo defaults to the maintainer's team and bundle ids. A fork needs both of

--- a/docs/watch.md
+++ b/docs/watch.md
@@ -47,9 +47,9 @@ labels all stop working. What replaces them:
   the percent, the source, **Empty Thu** / **Resets Thu** — but that is the
   same sentence the inline and corner families already say, and it cost a fifth
   of the height that makes the lines readable.
-- **The binding source's line is the only thick one.** The rest keep their
-  colours at lower opacity as context — the shape of the week, not a key to
-  decode.
+- **The binding source's line is the only thick one.** The rest keep full
+  colour as context — same as the board — and separate by weight, not by fading
+  out.
 - **The axis goes, the rhythm stays.** Day boundaries keep their rules and lose
   their labels; the scale keeps its lines and loses "100%".
 

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -479,6 +479,14 @@ struct SourceRow {
   bool enabled = true;
   bool ok = false;
   bool stale = false;
+  // The host's own login-is-dead flag. Absent on older hosts, which is why it
+  // defaults false rather than being inferred from `ok` — a host that cannot
+  // say must not be made to look like it said no.
+  bool authRequired = false;
+  // Age of *these numbers*, which is not the age of the last fetch. The board
+  // can be talking to the Mac every ten seconds while the Mac has been unable
+  // to refresh a source since last night.
+  int32_t ageS = -1;
 };
 static uint8_t sourceN = 0;
 static SourceRow sourceRows[MAX_SOURCES];
@@ -487,6 +495,29 @@ static bool sourceEnabled(const char *id) {
     if (sourceRows[i].id.equals(id)) return sourceRows[i].enabled;
   }
   return true;  // older hosts without sources[] → keep showing pages
+}
+
+// Oldest frozen reading on screen, in seconds, or -1 when everything the
+// board is drawing is current. Only enabled rows count: a source switched off
+// in Settings is not on any page, so its age is not a lie anyone can read.
+static int32_t sourcesWorstStaleS() {
+  int32_t worst = -1;
+  for (uint8_t i = 0; i < sourceN; i++) {
+    const SourceRow &r = sourceRows[i];
+    if (!r.enabled || !r.stale) continue;
+    if (r.ageS > worst) worst = r.ageS;
+  }
+  return worst;
+}
+
+// Whether any enabled source is behind a credential the Mac cannot use. The
+// board cannot fix this and does not pretend to — it marks the reading and
+// sends you to the Mac, which names the source and the command.
+static bool sourcesNeedSignIn() {
+  for (uint8_t i = 0; i < sourceN; i++) {
+    if (sourceRows[i].enabled && sourceRows[i].authRequired) return true;
+  }
+  return false;
 }
 
 // ---------------- I2C helpers ----------------
@@ -841,6 +872,8 @@ static bool usageFilterReady(JsonDocument **out) {
   filter["sources"][0]["enabled"] = true;
   filter["sources"][0]["ok"] = true;
   filter["sources"][0]["stale"] = true;
+  filter["sources"][0]["auth_required"] = true;
+  filter["sources"][0]["age_s"] = true;
   // Whole subtree, like codex/cursor above: device_view has already trimmed it
   // (one pool, or Total+API for Cursor), so there is nothing further to filter.
   filter["burndown"] = true;
@@ -1077,6 +1110,8 @@ static bool applyUsageDoc(JsonDocument &doc) {
       r.enabled = s["enabled"].isNull() ? true : (bool)(s["enabled"] | true);
       r.ok = s["ok"] | false;
       r.stale = s["stale"] | false;
+      r.authRequired = s["auth_required"] | false;
+      r.ageS = (int32_t)(s["age_s"] | -1);
     }
   }
 
@@ -2024,26 +2059,59 @@ static uint16_t dimToward(uint16_t color, uint16_t bg, float factor);
 static const int16_t LINK_GLYPH_W = 18;
 static const int16_t LINK_GLYPH_H = 15;
 
+// Compact enough for the corner: "42m", "11h", "3d". Minutes alone was fine
+// for a dropped link, which is minutes old by the time anyone looks, and
+// useless for a frozen reading — the case that sent us here would have drawn
+// "696m".
+static void formatAge(char *buf, size_t n, uint32_t seconds) {
+  if (seconds < 3600UL) {
+    snprintf(buf, n, "%lum", (unsigned long)(seconds / 60UL));
+  } else if (seconds < 86400UL) {
+    snprintf(buf, n, "%luh", (unsigned long)(seconds / 3600UL));
+  } else {
+    snprintf(buf, n, "%lud", (unsigned long)(seconds / 86400UL));
+  }
+}
+
 static void formatLastLinkAge(char *buf, size_t n) {
   if (!everOk) {
     snprintf(buf, n, "--m");
     return;
   }
-  const uint32_t minutes = (millis() - lastOkMs) / 60000UL;
-  snprintf(buf, n, "%lum", (unsigned long)minutes);
+  formatAge(buf, n, (millis() - lastOkMs) / 1000UL);
 }
 
 // Which pipe fed the numbers above: Wi-Fi arcs, or a cable.connector for USB.
 // (rightX, bottomY) is the bottom-right corner the glyph is tucked into.
 static void drawLinkGlyph(int16_t rightX, int16_t bottomY) {
-  const uint16_t col = hostOk ? COL_DIM : COL_CRT_YELLOW;
+  // Two different ways the numbers above can be wrong, and the glyph has to
+  // answer both. `hostOk` is the cable: it says whether the Mac answered.
+  // Stale sources are the payload: the Mac answers every ten seconds and has
+  // been unable to refresh a source since last night. Gating on `hostOk`
+  // alone drew nothing for the second case, which is the one that lasts.
+  const int32_t staleFor = sourcesWorstStaleS();
+  const bool signIn = sourcesNeedSignIn();
+  const bool suspect = !hostOk || staleFor >= 0 || signIn;
+  const uint16_t col = suspect ? COL_CRT_YELLOW : COL_DIM;
   const int16_t gx = (int16_t)(rightX - LINK_GLYPH_W);
   const int16_t gy = (int16_t)(bottomY - LINK_GLYPH_H);
 
-  if (!hostOk) {
+  if (suspect) {
     char age[8];
-    formatLastLinkAge(age, sizeof age);
-    drawRightAt(age, (int16_t)(gx - 6), gy, 2, col);
+    char label[12];
+    if (!hostOk) {
+      formatLastLinkAge(age, sizeof age);
+    } else if (staleFor >= 0) {
+      formatAge(age, sizeof age, (uint32_t)staleFor);
+    } else {
+      // A dead login the host caught before it had anything to replay: no
+      // frozen reading, so no age to report, but still worth marking.
+      snprintf(age, sizeof age, "--");
+    }
+    // The Mac names the source and the fix. This only has to say the reading
+    // is not what it looks like, and which kind of not.
+    snprintf(label, sizeof label, "%s%s", signIn ? "!" : "", age);
+    drawRightAt(label, (int16_t)(gx - 6), gy, 2, col);
   }
 
   if (linkVia == LINK_USB) {

--- a/host/cache_util.py
+++ b/host/cache_util.py
@@ -92,18 +92,29 @@ def store(cache, now, data, disk_name=None):
     if isinstance(data, dict):
         data["fetched_at"] = now
         data["stale"] = False
+        # A good fetch is proof the login works. Clearing it here rather than
+        # at each call site means no fetcher can leave the flag set on a
+        # payload it just refreshed.
+        data["auth_required"] = False
     if disk_name:
         save_disk(disk_name, data)
     cache.update(t=now, data=data, err=None)
     return data
 
 
-def keep_stale(cache, now, err, empty, disk_name=None):
+def keep_stale(cache, now, err, empty, disk_name=None, auth_required=False):
     """Prefer last-good snapshot on transient failure instead of wiping UI.
 
     `cache` is a dict with at least `data` (and usually `t`). On success paths
     callers still overwrite cache themselves. When `disk_name` is set, falls
     back to ~/.headroom/cache/<name>.json if memory is empty.
+
+    `auth_required` separates the one failure the user can actually fix from
+    every other reason a fetch misses. A rate limit, a dropped VPN and an
+    expired login all arrive here as a stale snapshot with a message, and a
+    surface that treats them alike can only say "not updating" — which reads
+    as something to wait out, and is exactly wrong for a login that will never
+    come back on its own.
 
     `fetched_at` rides along from the snapshot untouched. `cache["t"]` is when
     we last *tried*, which is what the retry TTL needs; the payload has to
@@ -118,6 +129,7 @@ def keep_stale(cache, now, err, empty, disk_name=None):
         stale = dict(prev)
         stale["stale"] = True
         stale["error"] = err
+        stale["auth_required"] = bool(auth_required)
         # Age from the last real fetch, not from the last attempt — every
         # attempt lands here, so counting attempts would keep resetting the
         # clock and a permanently broken source would read as fresh forever.
@@ -137,6 +149,7 @@ def keep_stale(cache, now, err, empty, disk_name=None):
     out["ok"] = False
     out["error"] = err
     out["stale"] = False
+    out["auth_required"] = bool(auth_required)
     cache.update(t=now, data=out, err=err)
     return out
 

--- a/host/device_view.py
+++ b/host/device_view.py
@@ -96,7 +96,12 @@ CURSOR_BURNDOWN_POOLS = ("total", "api")
 DEPLOY_FIELDS = ("project", "status", "target", "ago", "branch")
 COMMIT_FIELDS = ("repo", "subject", "ago", "branch")
 SERVER_FIELDS = ("name", "port", "cmd")
-SOURCE_FIELDS = ("id", "title", "enabled", "ok", "stale")
+# `auth_required` and `age_s` are what the board's corner glyph reads. Trimmed
+# out here they cost nothing on the wire and the glyph goes quiet on the one
+# failure that lasts — the Mac answering every ten seconds about numbers it has
+# not been able to refresh since last night.
+SOURCE_FIELDS = (
+    "id", "title", "enabled", "ok", "stale", "auth_required", "age_s")
 
 
 def _pick(src, fields):

--- a/host/headroom_server.py
+++ b/host/headroom_server.py
@@ -1029,12 +1029,19 @@ def _build_attention(doc):
     for provider in doc.get("providers") or []:
         if provider.get("kind") != "quota" or not provider.get("enabled"):
             continue
+        title = provider.get("title") or provider.get("id")
+        # A dead login is not a slow one, so it does not wait out STALE_ALERT_S
+        # first. Every minute spent under the stale threshold is a minute the
+        # meter reads plausibly and is not being refreshed by anyone, and no
+        # amount of waiting fixes it — outranking stale for the same reason.
+        if provider.get("auth_required"):
+            add("warn", "signin", f"{title} needs sign-in", 45)
+            continue
         held = provider.get("stale_for_s")
         if not provider.get("stale") or not isinstance(held, (int, float)):
             continue
         if held < cache_util.STALE_ALERT_S:
             continue
-        title = provider.get("title") or provider.get("id")
         add(
             "warn",
             "stale",
@@ -1113,6 +1120,10 @@ def _sources_payload(state):
             "enabled": bool(enabled.get(source.id, True)),
             "ok": bool(payload.get("ok")),
             "stale": bool(payload.get("stale")),
+            # The login is gone or rejected. Distinct from `stale`, which this
+            # also sets: staleness says the numbers stopped, this says why and
+            # who can fix it.
+            "auth_required": bool(payload.get("auth_required")),
             "configured": payload.get("configured"),
             "error": payload.get("error"),
             "detail": sources_config.detail_for(source.id, payload),
@@ -1187,6 +1198,10 @@ def _providers_payload(state, burndowns=None):
             # that is now deliberately absent, which is not a difference a
             # reader can be expected to notice.
             "stale": bool(payload.get("stale")),
+            # Why the bars froze, when the answer is a login. Clients word a
+            # dead credential differently from a provider that is merely
+            # unreachable, because only one of them is the reader's to fix.
+            "auth_required": bool(payload.get("auth_required")),
             "age_s": age,
             # Follow-up clients use the explicit stale-duration name. Keep
             # age_s for clients already shipped against the first freshness

--- a/host/oauth_usage.py
+++ b/host/oauth_usage.py
@@ -613,20 +613,24 @@ def fetch_quota(force=False, account=None):
 
     empty = {"ok": False, "plan": None, "session": None, "week": None, "error": None}
 
-    def _keep_stale(err):
+    def _keep_stale(err, auth_required=False):
         return cache_util.keep_stale(
-            cache, now, err, empty, disk_name=disk_name)
+            cache, now, err, empty, disk_name=disk_name,
+            auth_required=auth_required)
 
     try:
         try:
             store, blob, oauth = _load_oauth(account)
         except KeychainRefused as exc:
             return _keep_stale(str(exc))
+        # Nothing to authenticate with, and nothing here gets better on a
+        # retry: both want a `claude login`, not patience.
         if not store:
             return _keep_stale(
-                f"no Claude credentials in {_credentials_hint(account)}")
+                f"no Claude credentials in {_credentials_hint(account)}",
+                auth_required=True)
         if not oauth:
-            return _keep_stale(_shape_hint(store, blob))
+            return _keep_stale(_shape_hint(store, blob), auth_required=True)
 
         if _needs_refresh(oauth):
             try:
@@ -648,8 +652,15 @@ def fetch_quota(force=False, account=None):
                     return _keep_stale(str(exc))
                 if not oauth:
                     return _keep_stale(
-                        f"HTTP Error {e.code}: {e.reason}")
-                oauth = _refresh(oauth, store, blob, account=account)
+                        f"HTTP Error {e.code}: {e.reason}", auth_required=True)
+                try:
+                    oauth = _refresh(oauth, store, blob, account=account)
+                except Exception as exc:
+                    # The token was rejected and the refresh could not replace
+                    # it. Left to the outer handler this reads as a generic
+                    # failure, when it is the same dead login as a missing
+                    # token and wants the same fix.
+                    return _keep_stale(str(exc), auth_required=True)
                 status, body = _http_get_usage(oauth["accessToken"])
             else:
                 # 429 / 5xx — keep last good bars instead of wiping the page.

--- a/host/test_stale_quota.py
+++ b/host/test_stale_quota.py
@@ -15,6 +15,7 @@ import os
 import tempfile
 import time
 import unittest
+import urllib.error
 from unittest.mock import patch
 
 import accounts
@@ -339,3 +340,119 @@ class StaleDerivationTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class AuthRequiredTests(unittest.TestCase):
+    """A dead login is not a slow fetch, and the payload has to say which.
+
+    Both arrive as a stale snapshot with a message attached, which is why the
+    Mac spent eleven hours reporting a missing Claude token as "Not updating"
+    — true, unactionable, and indistinguishable from a rate limit.
+    """
+
+    def setUp(self):
+        oauth_usage.reset_for_tests()
+        self._oauth_home = tempfile.TemporaryDirectory()
+        self.addCleanup(self._oauth_home.cleanup)
+        self._oauth_patch = patch.object(
+            oauth_usage, "OAUTH_DIR", self._oauth_home.name)
+        self._oauth_patch.start()
+        self.addCleanup(self._oauth_patch.stop)
+
+    def test_keep_stale_defaults_to_not_an_auth_problem(self):
+        cache = {"t": 0.0, "data": None, "err": None}
+        cache_util.store(cache, NOW, {"ok": True, "pct": 42})
+        out = cache_util.keep_stale(cache, NOW + 60, "HTTP Error 429", {"ok": False})
+        self.assertTrue(out["stale"])
+        self.assertFalse(out["auth_required"])
+
+    def test_keep_stale_marks_an_auth_problem_when_told(self):
+        cache = {"t": 0.0, "data": None, "err": None}
+        cache_util.store(cache, NOW, {"ok": True, "pct": 42})
+        out = cache_util.keep_stale(
+            cache, NOW + 60, "no token", {"ok": False}, auth_required=True)
+        self.assertTrue(out["stale"])
+        self.assertTrue(out["auth_required"])
+
+    def test_a_provider_that_never_fetched_still_reports_the_flag(self):
+        # No prior snapshot to replay: the empty branch has to carry it too,
+        # or a first run with no login looks like a provider that is merely
+        # not configured.
+        cache = {"t": 0.0, "data": None, "err": None}
+        out = cache_util.keep_stale(
+            cache, NOW, "no token", {"ok": False}, auth_required=True)
+        self.assertFalse(out["stale"])
+        self.assertTrue(out["auth_required"])
+
+    def test_a_good_fetch_clears_the_flag(self):
+        cache = {"t": 0.0, "data": None, "err": None}
+        cache_util.keep_stale(
+            cache, NOW, "no token", {"ok": False}, auth_required=True)
+        out = cache_util.store(cache, NOW + 60, {"ok": True, "pct": 42})
+        self.assertFalse(out["auth_required"])
+
+    def test_a_store_holding_only_mcp_oauth_asks_for_a_login(self):
+        # The exact shape that broke: Claude Code's Keychain item present and
+        # parseable, holding MCP plugin tokens and no plan token.
+        blob = {"mcpOAuth": {"plugin:x|abc": {"accessToken": "mcp-token"}}}
+        with patch.object(oauth_usage, "_read_creds_blob",
+                          return_value=("keychain", blob)):
+            out = oauth_usage.fetch_quota(force=True)
+        self.assertTrue(out["auth_required"])
+        self.assertIn("claudeAiOauth", out["error"])
+
+    def test_no_credentials_anywhere_asks_for_a_login(self):
+        with patch.object(oauth_usage, "_read_creds_blob",
+                          return_value=(None, None)):
+            out = oauth_usage.fetch_quota(force=True)
+        self.assertTrue(out["auth_required"])
+
+    def test_a_rate_limit_is_not_an_auth_problem(self):
+        blob = {"claudeAiOauth": {"accessToken": "t", "refreshToken": "r"}}
+        boom = urllib.error.HTTPError(
+            oauth_usage.USAGE_URL, 429, "Too Many Requests", None, None)
+        with patch.object(oauth_usage, "_read_creds_blob",
+                          return_value=("keychain", blob)), \
+             patch.object(oauth_usage, "_http_get_usage", side_effect=boom):
+            out = oauth_usage.fetch_quota(force=True)
+        self.assertFalse(out["auth_required"])
+        self.assertIn("429", out["error"])
+
+    def test_the_flag_reaches_providers_and_sources(self):
+        state = {"claude": quota_payload(
+            stale=True, auth_required=True, error="no plan token")}
+
+        providers = headroom_server._providers_payload(state, burndowns={})
+        claude = next(row for row in providers if row["id"] == "claude")
+        self.assertTrue(claude["auth_required"])
+        # Still ok, still replaying bars — which is exactly why the flag has
+        # to travel separately from `ok`.
+        self.assertTrue(claude["ok"])
+
+        sources = headroom_server._sources_payload(state)
+        row = next(row for row in sources if row["id"] == "claude")
+        self.assertTrue(row["auth_required"])
+        self.assertTrue(row["ok"])
+
+    def test_a_healthy_source_carries_the_flag_as_false(self):
+        # Absent would be indistinguishable from an older host on the wire,
+        # and clients read a missing flag as "this host cannot tell me".
+        state = {"claude": quota_payload()}
+        row = next(r for r in headroom_server._sources_payload(state)
+                   if r["id"] == "claude")
+        self.assertFalse(row["auth_required"])
+
+    def test_attention_calls_out_a_login_without_waiting_for_stale(self):
+        # Under STALE_ALERT_S, so the stale reason would not fire yet. A login
+        # that is gone does not get more fixed by waiting fifteen minutes.
+        doc = {"providers": [{
+            "id": "claude", "title": "Claude", "kind": "quota",
+            "enabled": True, "ok": True, "stale": True,
+            "auth_required": True, "stale_for_s": 60,
+        }]}
+        reasons = headroom_server._build_attention(doc)["reasons"]
+        kinds = [r["kind"] for r in reasons]
+        self.assertIn("signin", kinds)
+        self.assertNotIn("stale", kinds)
+        summary = next(r["summary"] for r in reasons if r["kind"] == "signin")
+        self.assertEqual(summary, "Claude needs sign-in")

--- a/ios/HeadroomMobile/MobileConnection.swift
+++ b/ios/HeadroomMobile/MobileConnection.swift
@@ -14,6 +14,28 @@ enum MobileConnection {
         UserDefaults.standard.bool(forKey: configuredKey)
     }
 
+    /// Host from the saved endpoint — `.local` name, MagicDNS, or IP.
+    static var hostLabel: String {
+        URL(string: endpoint)?.host() ?? endpoint
+    }
+
+    /// One-line Mac identity for the Overview status tile.
+    ///
+    /// Prefer the Computer Name from `/usage` when it adds something the host
+    /// does not already say; otherwise just the address you paired with.
+    static func identityLabel(machineName: String?) -> String {
+        let host = hostLabel
+        guard let name = machineName?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !name.isEmpty else { return host }
+        let hostBase = host.split(separator: ".").first.map(String.init) ?? host
+        if name.caseInsensitiveCompare(host) == .orderedSame
+            || name.caseInsensitiveCompare(hostBase) == .orderedSame {
+            return host
+        }
+        return "\(name) · \(host)"
+    }
+
     static func normalize(_ input: String) -> String? {
         var value = input.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !value.isEmpty else { return nil }

--- a/ios/HeadroomMobile/MobileSettingsScreen.swift
+++ b/ios/HeadroomMobile/MobileSettingsScreen.swift
@@ -46,10 +46,15 @@ struct MobileSettingsScreen: View {
     private var connectionPane: some View {
         Form {
             Section {
-                LabeledContent("Mac", value: connectionName)
+                if let name = store.snapshot.currentMachine?.name, !name.isEmpty {
+                    LabeledContent("Mac", value: name)
+                }
+                LabeledContent("Address", value: connectionName)
                 Button("Change connection", systemImage: "network") {
                     showsConnection = true
                 }
+            } footer: {
+                Text(MobileConnection.endpoint)
             }
             Section {
                 NavigationLink(value: SettingsDestination.permissions) {
@@ -138,7 +143,7 @@ struct MobileSettingsScreen: View {
     }
 
     private var connectionName: String {
-        URL(string: MobileConnection.endpoint)?.host() ?? MobileConnection.endpoint
+        MobileConnection.hostLabel
     }
 
     private var groupedSources: [(group: SourceGroup, sources: [SyncSource])] {

--- a/ios/HeadroomMobile/QuotaViews.swift
+++ b/ios/HeadroomMobile/QuotaViews.swift
@@ -99,7 +99,7 @@ private struct ProviderSummaryRow: View {
                 tint: provider.tint
             )
             .frame(width: 82, height: 82)
-            .opacity(provider.isStale ? 0.4 : 1)
+            .opacity(provider.readingSuspect ? 0.4 : 1)
 
             VStack(alignment: .leading, spacing: 4) {
                 HStack {
@@ -124,12 +124,16 @@ private struct ProviderSummaryRow: View {
                 }
                 // Ahead of the headline, because a headline written from
                 // frozen percentages is confidently wrong.
-                if let stale = provider.staleNote {
-                    Text(stale)
+                if let status = provider.statusNote {
+                    Text(status)
                         .font(.caption2)
                         .foregroundStyle(HeadroomPalette.amber)
                         .lineLimit(1)
-                } else if provider.ok == false, let error = provider.error {
+                }
+                // Same reasoning as the Mac card: `ok` stays true while the
+                // host replays frozen bars, so an error is worth showing
+                // whenever there is one.
+                if let error = provider.error {
                     Text(error)
                         .font(.caption2)
                         .foregroundStyle(HeadroomPalette.amber)
@@ -154,12 +158,12 @@ private struct ProviderQuotaDetail: View {
     /// "Connected" is a claim about right now, and a provider whose numbers
     /// stopped arriving is in no position to make it. `ok` alone would let it.
     private var statusLabel: String {
-        if let stale = provider.staleNote { return stale }
+        if let status = provider.statusNote { return status }
         return provider.ok == false ? HeadroomCopy.needsAttention : "Connected"
     }
 
     private var statusTint: Color {
-        provider.ok == false || provider.isStale
+        provider.ok == false || provider.readingSuspect
             ? HeadroomPalette.amber
             : HeadroomPalette.green
     }
@@ -174,7 +178,7 @@ private struct ProviderQuotaDetail: View {
                             tint: provider.tint
                         )
                         .frame(width: 112, height: 112)
-                        .opacity(provider.isStale ? 0.4 : 1)
+                        .opacity(provider.readingSuspect ? 0.4 : 1)
                         Spacer()
                         VStack(alignment: .trailing, spacing: 4) {
                             Text(provider.plan ?? "Plan unavailable")

--- a/ios/HeadroomMobile/RootView.swift
+++ b/ios/HeadroomMobile/RootView.swift
@@ -178,18 +178,22 @@ struct MobileStatusCard: View {
     }
 
     private var statusSubtitle: String {
+        let identity = MobileConnection.identityLabel(
+            machineName: store.snapshot.currentMachine?.name
+        )
         if let error = store.errorMessage {
-            guard let age = store.age else { return error }
-            return "\(HeadroomCopy.ago(age)) · \(error)"
+            guard let age = store.age else { return "\(identity) · \(error)" }
+            return "\(identity) · \(HeadroomCopy.ago(age)) · \(error)"
         }
         // Archived and not yet contradicted: the fetch is still in flight.
         if store.isShowingArchive, let age = store.age {
-            return HeadroomCopy.ago(age)
+            return "\(identity) · \(HeadroomCopy.ago(age))"
         }
         if let date = store.capturedAt {
-            return "Updated \(date.formatted(date: .omitted, time: .shortened))"
+            let updated = date.formatted(date: .omitted, time: .shortened)
+            return "\(identity) · Updated \(updated)"
         }
-        return MobileConnection.endpoint
+        return identity
     }
 
     private var statusColor: Color {

--- a/ios/HeadroomMobileTests/MobileContractTests.swift
+++ b/ios/HeadroomMobileTests/MobileContractTests.swift
@@ -41,6 +41,28 @@ final class MobileContractTests: XCTestCase {
         )
     }
 
+    func testIdentityLabelPrefersDistinctMachineName() {
+        UserDefaults.standard.set(
+            "http://studio-mac.local:8737/usage",
+            forKey: MobileConnection.endpointKey
+        )
+        defer {
+            UserDefaults.standard.removeObject(forKey: MobileConnection.endpointKey)
+        }
+        XCTAssertEqual(
+            MobileConnection.identityLabel(machineName: "Studio"),
+            "Studio · studio-mac.local"
+        )
+        XCTAssertEqual(
+            MobileConnection.identityLabel(machineName: "studio-mac"),
+            "studio-mac.local"
+        )
+        XCTAssertEqual(
+            MobileConnection.identityLabel(machineName: nil),
+            "studio-mac.local"
+        )
+    }
+
     func testHeadroomCopyMatchesGlossaryTerms() {
         XCTAssertEqual(HeadroomCopy.dailyBurn, "Daily burn")
         XCTAssertEqual(HeadroomCopy.overallBurndown, "Overall burndown")

--- a/macos/Sources/QuotaSection.swift
+++ b/macos/Sources/QuotaSection.swift
@@ -146,12 +146,21 @@ struct ProviderQuotaCard: View {
             }
             // Above the error, and shown even though `ok` is true: every bar
             // on this card is a number the Mac stopped being able to refresh.
-            if let stale = meter.staleNote {
-                Label(stale, systemImage: "exclamationmark.arrow.circlepath")
-                    .font(.caption)
-                    .foregroundStyle(HeadroomPalette.amber)
+            if let status = meter.statusNote {
+                Label(
+                    status,
+                    systemImage: meter.needsSignIn
+                        ? "person.badge.key"
+                        : "exclamationmark.arrow.circlepath"
+                )
+                .font(.caption)
+                .foregroundStyle(HeadroomPalette.amber)
             }
-            if !meter.ok, let error = meter.error {
+            // Not gated on `ok`. The host holds `ok` true while it replays the
+            // last good bars, so gating here hid the message on exactly the
+            // failures that had one worth reading — including the one that
+            // named the command to run.
+            if let error = meter.error {
                 Text(error)
                     .font(.caption)
                     .foregroundStyle(HeadroomPalette.amber)
@@ -276,7 +285,7 @@ struct ProviderQuotaRing: View {
     /// glyph that actively insists a frozen meter is live. When the host says
     /// the fetch is failing, the age of the data replaces it.
     private var windowCaption: String {
-        if let note = provider.staleNote { return note }
+        if let note = provider.statusNote { return note }
         if let reset = headline.reset, !reset.isEmpty {
             return "\(headline.title) · \(reset)"
         }
@@ -289,7 +298,7 @@ struct ProviderQuotaRing: View {
             .frame(width: diameter, height: diameter)
             // Drained of colour, because the gap between arc and pace dot is
             // the reading, and on frozen numbers that reading is fiction.
-            .opacity(provider.isStale ? 0.4 : 1)
+            .opacity(provider.readingSuspect ? 0.4 : 1)
             Text(meter.title)
                 .font(.footnote.weight(.medium))
                 .foregroundStyle(tint)
@@ -297,7 +306,7 @@ struct ProviderQuotaRing: View {
                 .minimumScaleFactor(0.8)
             Text(windowCaption)
                 .font(.caption2)
-                .foregroundStyle(provider.isStale ? HeadroomPalette.amber : .secondary)
+                .foregroundStyle(provider.readingSuspect ? HeadroomPalette.amber : .secondary)
                 .monospacedDigit()
                 .lineLimit(1)
                 .minimumScaleFactor(0.85)

--- a/macos/Sources/Settings/SettingsSourceRow.swift
+++ b/macos/Sources/Settings/SettingsSourceRow.swift
@@ -140,6 +140,12 @@ struct SourceRow: View {
 
     private var secondaryLine: String {
         var parts: [String] = []
+        // Leads, and replaces the registry hint rather than joining it: the
+        // hint says where the credential is meant to live, which is the least
+        // useful sentence available once we know what is there is not valid.
+        if source.needsSignIn {
+            parts.append(HeadroomCopy.needsSignIn)
+        }
         if let detail = source.detail ?? source.hint ?? source.error {
             parts.append(detail)
         }
@@ -152,6 +158,7 @@ struct SourceRow: View {
     /// Color is not the only carrier of health — VoiceOver gets it in words.
     private var statusLabel: String {
         if !enabled { return "Off" }
+        if source.needsSignIn { return HeadroomCopy.needsSignIn }
         if source.ok != true { return "Error" }
         return source.stale == true ? "Stale" : "Healthy"
     }
@@ -159,6 +166,10 @@ struct SourceRow: View {
     /// Health: green / amber / red, the same words the rest of the app uses.
     private var statusColor: Color {
         if !enabled { return HeadroomPalette.dim }
+        // Red even while `ok` is true and bars are still drawn. Amber is for a
+        // source that is degraded and may recover; this one has stopped and
+        // will stay stopped until someone signs in.
+        if source.needsSignIn { return HeadroomPalette.red }
         if source.ok == true {
             return source.stale == true ? HeadroomPalette.amber : HeadroomPalette.green
         }

--- a/macos/Sources/Settings/SettingsView.swift
+++ b/macos/Sources/Settings/SettingsView.swift
@@ -192,30 +192,6 @@ struct SettingsView: View {
             }
             .onAppear(perform: refreshOpenAtLogin)
 
-            Section("Dashboard") {
-                Stepper(
-                    "\(HeadroomCopy.activity) rows: \(activityRowLimit)",
-                    value: $activityRowLimit,
-                    in: 3...14
-                )
-                Stepper(
-                    "\(HeadroomCopy.localServers): \(serverRowLimit)",
-                    value: $serverRowLimit,
-                    in: 1...8
-                )
-                Stepper(
-                    "Supabase projects: \(supabaseRowLimit)",
-                    value: $supabaseRowLimit,
-                    in: 1...20
-                )
-                Stepper(
-                    "Plausible sites: \(plausibleRowLimit)",
-                    value: $plausibleRowLimit,
-                    in: 1...20
-                )
-                Toggle("Confirm before stopping servers", isOn: $confirmServerStops)
-            }
-
             Section {
                 NavigationLink(value: SettingsDestination.otherMacs) {
                     LabeledContent(HeadroomCopy.otherMacs) {
@@ -603,6 +579,30 @@ struct SettingsView: View {
                 }
             } footer: {
                 Text("Keys stay in the Keychain on this Mac. The iPhone never sees them.")
+            }
+
+            Section("Dashboard") {
+                Stepper(
+                    "\(HeadroomCopy.activity) rows: \(activityRowLimit)",
+                    value: $activityRowLimit,
+                    in: 3...14
+                )
+                Stepper(
+                    "\(HeadroomCopy.localServers): \(serverRowLimit)",
+                    value: $serverRowLimit,
+                    in: 1...8
+                )
+                Stepper(
+                    "Supabase projects: \(supabaseRowLimit)",
+                    value: $supabaseRowLimit,
+                    in: 1...20
+                )
+                Stepper(
+                    "Plausible sites: \(plausibleRowLimit)",
+                    value: $plausibleRowLimit,
+                    in: 1...20
+                )
+                Toggle("Confirm before stopping servers", isOn: $confirmServerStops)
             }
         }
         .formStyle(.grouped)

--- a/macos/Tests/ContractTests.swift
+++ b/macos/Tests/ContractTests.swift
@@ -308,14 +308,76 @@ final class ContractTests: XCTestCase {
             snapshot.providers?.first { $0.id == "claude" })
         XCTAssertEqual(claude.ok, true)
         XCTAssertTrue(claude.isStale)
-        XCTAssertEqual(claude.staleNote, "Not updating · 2 hours ago")
-        XCTAssertEqual(snapshot.meter(for: claude).staleNote, claude.staleNote)
+        XCTAssertFalse(claude.needsSignIn)
+        XCTAssertEqual(claude.statusNote, "Not updating · 2 hours ago")
+        XCTAssertEqual(snapshot.meter(for: claude).statusNote, claude.statusNote)
 
         let codex = try XCTUnwrap(
             snapshot.providers?.first { $0.id == "codex" })
         XCTAssertFalse(codex.isStale)
-        XCTAssertNil(codex.staleNote)
-        XCTAssertNil(snapshot.meter(for: codex).staleNote)
+        XCTAssertNil(codex.statusNote)
+        XCTAssertNil(snapshot.meter(for: codex).statusNote)
+    }
+
+    func testADeadLoginSaysSignInRatherThanNotUpdating() throws {
+        // The failure that sent us here: `ok` true, bars replayed, and the one
+        // string naming the fix suppressed because nothing looked wrong. Both
+        // flags are set on the wire, and the sign-in wording has to win —
+        // "Not updating" reads as a hiccup to wait out, and this one never
+        // clears on its own.
+        let json = """
+        {
+          "providers": [
+            {"id": "claude", "title": "Claude", "kind": "quota",
+             "enabled": true, "ok": true, "stale": true,
+             "auth_required": true, "stale_for_s": 41896,
+             "error": "keychain has no claudeAiOauth.accessToken",
+             "headline": "week",
+             "pools": {
+               "week": {"title": "Weekly", "pct": 53.0, "ring": true}
+             }}
+          ],
+          "sources": [
+            {"id": "claude", "title": "Claude", "kind": "quota",
+             "enabled": true, "ok": true, "stale": true,
+             "auth_required": true}
+          ]
+        }
+        """
+        let snapshot = try JSONDecoder().decode(
+            UsageSnapshot.self, from: Data(json.utf8))
+        let claude = try XCTUnwrap(snapshot.providers?.first)
+        XCTAssertEqual(claude.ok, true)
+        XCTAssertTrue(claude.isStale)
+        XCTAssertTrue(claude.needsSignIn)
+        XCTAssertTrue(claude.readingSuspect)
+        XCTAssertEqual(claude.statusNote, "Needs sign-in · 12 hours ago")
+
+        let meter = snapshot.meter(for: claude)
+        XCTAssertTrue(meter.needsSignIn)
+        XCTAssertEqual(meter.statusNote, claude.statusNote)
+        // The card draws this whenever it is non-nil now, so the reason
+        // reaches the reader while `ok` is still true.
+        XCTAssertEqual(meter.error, "keychain has no claudeAiOauth.accessToken")
+
+        let row = try XCTUnwrap(snapshot.sources?.first)
+        XCTAssertTrue(row.needsSignIn)
+    }
+
+    func testAProviderThatNeverFetchedStillAsksForSignIn() throws {
+        // No snapshot to replay, so nothing is stale and there is no age to
+        // report — the card is empty and still owes a reason.
+        let json = """
+        {"providers": [{"id": "claude", "kind": "quota", "ok": false,
+                        "auth_required": true}]}
+        """
+        let snapshot = try JSONDecoder().decode(
+            UsageSnapshot.self, from: Data(json.utf8))
+        let claude = try XCTUnwrap(snapshot.providers?.first)
+        XCTAssertFalse(claude.isStale)
+        XCTAssertTrue(claude.needsSignIn)
+        XCTAssertTrue(claude.readingSuspect)
+        XCTAssertEqual(claude.statusNote, "Needs sign-in")
     }
 
     func testAHostWithoutTheStaleFieldReadsAsFetching() throws {
@@ -327,7 +389,8 @@ final class ContractTests: XCTestCase {
             UsageSnapshot.self, from: Data(json.utf8))
         let claude = try XCTUnwrap(snapshot.providers?.first)
         XCTAssertFalse(claude.isStale)
-        XCTAssertNil(claude.staleNote)
+        XCTAssertFalse(claude.needsSignIn)
+        XCTAssertNil(claude.statusNote)
     }
 
     func testMissingProvidersAndSourcesYieldEmptyActiveSet() throws {

--- a/watch/Shared/WatchRundown.swift
+++ b/watch/Shared/WatchRundown.swift
@@ -14,9 +14,9 @@ import SwiftUI
 ///     deadline it used to carry are the same sentence the inline and corner
 ///     families already say, and repeating them cost a fifth of the height
 ///     that makes the line readable.
-///   * **The binding source's line is the only thick one.** The rest keep their
-///     colours at lower opacity as context: the shape of the week, not a legend
-///     to decode.
+///   * **The binding source's line is the only thick one.** The rest keep full
+///     colour as context — same as the board — and separate by weight, not by
+///     fading out.
 ///   * **The axis goes, the rhythm stays.** Day boundaries keep their rules and
 ///     lose their labels; the scale keeps its three lines and loses "100%".
 ///
@@ -107,31 +107,9 @@ struct WatchRundownChart: View {
         static let emptyContext: CGFloat = 4.5
     }
 
-    /// The source's colour at the one opacity that fits both facts about it:
-    /// whether it is the named source, and whether its pool is spent.
-    ///
-    /// Deliberately not `burndownTint`, which already dims a spent pool to
-    /// 0.45. `Color.opacity` multiplies, so dimming that again for a context
-    /// line lands at a quarter — a weight chosen by accident, and invisible on
-    /// a wrist. Setting it once from both facts keeps the floor at 0.45, which
-    /// is the faintest thing on this chart that still reads as a line.
-    private static func ink(
-        for provider: HeadroomWidgetSnapshot.Provider,
-        leading: Bool
-    ) -> Color {
-        let spent = provider.burndown?.exhausted == true
-        let alpha: Double = switch (leading, spent) {
-        case (true, false): 1
-        case (true, true): 0.65
-        case (false, false): 0.6
-        case (false, true): 0.45
-        }
-        return provider.watchTint.opacity(alpha)
-    }
-
-    /// One source's week, in that source's colour. `leading` is the named one:
-    /// full strength and thicker, so it separates from the context lines
-    /// without needing the legend there is no room for.
+    /// One source's week, in that source's colour. Every line is opaque — same
+    /// as the board — and `leading` is only thicker, so it separates from the
+    /// context lines without needing the legend there is no room for.
     private static func draw(
         _ provider: HeadroomWidgetSnapshot.Provider,
         in context: inout GraphicsContext,
@@ -139,7 +117,7 @@ struct WatchRundownChart: View {
         leading: Bool
     ) {
         guard let series = provider.burndown else { return }
-        let ink = Self.ink(for: provider, leading: leading)
+        let ink = provider.watchTint
 
         let actual = OverallBurndownChartMath.preparedActual(
             series.actual, domain: plot.domain


### PR DESCRIPTION
A dead Claude login was indistinguishable from a rate limit: the host keeps `ok` true while it replays a source's last good bars, so the Mac spent eleven hours showing **Not updating** for something no amount of waiting would fix, and the one string naming `claude login` was suppressed because nothing looked wrong.

## What changed

**Host** ships `auth_required` beside `stale` on `providers[]` and `sources[]`. `store()` clears it on any good fetch, so no fetcher can leave it set on a payload it just refreshed. A 429 does not set it; a missing token, a wrong blob shape, a 401 with no refresh token, and a failed refresh all do. Attention fires a `signin` reason immediately rather than waiting out `STALE_ALERT_S`.

**Clients** rename `staleNote` → `statusNote`, add `needsSignIn` / `readingSuspect`, and let sign-in wording outrank stale wherever both are true. Quota card errors are no longer gated on `ok` — that gate is what hid the message on exactly the failures worth reading. Settings shows a sign-in row red rather than amber: amber is for degraded and may recover.

**ESP32** corner glyph marks a frozen reading, not just a dropped cable. It was gated on whether the Mac answered, so the case that lasts drew nothing. Ages read `42m` / `11h` / `3d`; a login is prefixed `!`.

Riding along, unrelated but in the same tree: iOS Overview names the Mac and its address, watch burndown context lines go fully opaque to match the board, `docs/attention.md` records rollup scoring as product policy rather than a Settings pane, and the README/CONTRIBUTING build instructions stop being wrong about XcodeGen and `-sdk iphonesimulator`.

## Verification

All five gates green locally at `2e8588d`:

- `check-glossary-copy.sh` ok
- macOS `xcodebuild test` — 43 tests, 0 failures
- iOS build (beta toolchain) — succeeded
- watchOS build (beta toolchain) — succeeded
- ESP32 `pio run` — succeeded
- host `test_stale_quota` 34 ok, `test_contract` 22 ok

`test_contract` caught one real defect during the run: the firmware's `usageFilter()` was reading `sources[].auth_required` and `age_s`, which `device_view.py` trimmed out of its whitelist. The board would have filtered for keys that never arrived. Fixed in 2e8588d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)