### PR TITLE
fix(host): back off failing quota fetches instead of hammering them

### DIFF
--- a/host/cache_util.py
+++ b/host/cache_util.py
@@ -65,17 +65,44 @@ def save_disk(name: str, data: dict) -> None:
         pass
 
 
+# A failure that keeps failing doubles its retry interval up to this cap.
+# The short `fail_ttl_s` exists so a blip clears in seconds — but against a
+# rate limit it is the disease: three Claude accounts retrying every 20s is
+# nine requests a minute from one IP, enough to sustain the very 429 they are
+# retrying. Doubling reaches the cap in minutes, and a recovered provider is
+# then at most one cap behind. Kept below no ceiling a human notices: Refresh
+# all still forces an immediate attempt.
+FAIL_BACKOFF_CAP_S = 15 * 60
+
+# Ceiling on a provider-sent Retry-After. It is an instruction, not a
+# suggestion, so it may push the wait past the doubling cap — but an
+# ill-formed or hostile header must not park a source for a day.
+RETRY_AFTER_CAP_S = 60 * 60
+
+
+def _fail_ttl_s(cache, fail_ttl_s):
+    """Seconds to sit on a failure before retrying, given the streak so far."""
+    streak = int(cache.get("fail_streak") or 1)
+    ttl = min(fail_ttl_s * (2 ** max(0, streak - 1)), FAIL_BACKOFF_CAP_S)
+    floor = cache.get("retry_after_s")
+    if isinstance(floor, (int, float)) and floor > 0:
+        ttl = max(ttl, min(float(floor), RETRY_AFTER_CAP_S))
+    return ttl
+
+
 def fresh(cache, now, ttl_s, fail_ttl_s, force=False):
     """True when the in-memory copy is young enough to serve as-is.
 
     A cache holding an error retries on the shorter `fail_ttl_s`, so a 429 or
     a dropped VPN clears in seconds rather than making the meter sit wrong for
-    a full TTL.
+    a full TTL. Consecutive failures back that interval off exponentially
+    (`_fail_ttl_s`), so a failure that is not transient stops being polled as
+    if it were.
     """
     if force or cache.get("data") is None:
         return False
     return now - cache.get("t", 0.0) < (
-        fail_ttl_s if cache.get("err") else ttl_s
+        _fail_ttl_s(cache, fail_ttl_s) if cache.get("err") else ttl_s
     )
 
 
@@ -98,11 +125,18 @@ def store(cache, now, data, disk_name=None):
         data["auth_required"] = False
     if disk_name:
         save_disk(disk_name, data)
+    # A good fetch ends the failure streak; the next miss starts over at the
+    # short TTL instead of inheriting a backoff earned by an outage that is
+    # over.
+    cache.pop("fail_streak", None)
+    cache.pop("retry_after_s", None)
+    cache.pop("stale_since", None)
     cache.update(t=now, data=data, err=None)
     return data
 
 
-def keep_stale(cache, now, err, empty, disk_name=None, auth_required=False):
+def keep_stale(cache, now, err, empty, disk_name=None, auth_required=False,
+               retry_after_s=None):
     """Prefer last-good snapshot on transient failure instead of wiping UI.
 
     `cache` is a dict with at least `data` (and usually `t`). On success paths
@@ -121,7 +155,16 @@ def keep_stale(cache, now, err, empty, disk_name=None, auth_required=False):
     carry when the numbers were last *true*, or a source that has been failing
     for a day reads as one poll old and nothing downstream can tell the
     difference.
+
+    `retry_after_s` is a provider-mandated wait (the Retry-After header on a
+    429). It floors the next retry interval; pass it only when the provider
+    actually said so, or the backoff loses the one number that is not a guess.
     """
+    cache["fail_streak"] = int(cache.get("fail_streak") or 0) + 1
+    if isinstance(retry_after_s, (int, float)) and retry_after_s > 0:
+        cache["retry_after_s"] = float(retry_after_s)
+    else:
+        cache.pop("retry_after_s", None)
     prev = cache.get("data")
     if not (prev and prev.get("ok")) and disk_name:
         prev = load_disk(disk_name)

--- a/host/oauth_usage.py
+++ b/host/oauth_usage.py
@@ -55,7 +55,23 @@ KEYCHAIN_STORE_PREFIX = "keychain:"
 HEADROOM_STORE_PREFIX = "headroom:"
 OAUTH_DIR = os.path.expanduser("~/.headroom/oauth")
 CACHE_TTL_S = 60
-FAIL_TTL_S = 20          # retry sooner after transient misses (429, etc.)
+# First retry after a miss. Consecutive failures back off from here
+# (cache_util._fail_ttl_s) — without that, several accounts on this short a
+# leash hammer a rate-limited endpoint hard enough to keep it rate-limited.
+FAIL_TTL_S = 20
+
+
+def _retry_after_s(err):
+    """Seconds a 429/503 asked us to wait, or None.
+
+    Only the delta-seconds form; the HTTP-date form is rare enough here that
+    guessing at clock skew is worse than falling back to our own backoff.
+    """
+    try:
+        raw = err.headers.get("Retry-After")
+        return float(raw) if raw else None
+    except (AttributeError, TypeError, ValueError):
+        return None
 EXPIRY_SKEW_S = 120
 
 # One cache per account, keyed by account id ("" is the default login). The
@@ -613,10 +629,10 @@ def fetch_quota(force=False, account=None):
 
     empty = {"ok": False, "plan": None, "session": None, "week": None, "error": None}
 
-    def _keep_stale(err, auth_required=False):
+    def _keep_stale(err, auth_required=False, retry_after_s=None):
         return cache_util.keep_stale(
             cache, now, err, empty, disk_name=disk_name,
-            auth_required=auth_required)
+            auth_required=auth_required, retry_after_s=retry_after_s)
 
     try:
         try:
@@ -663,8 +679,11 @@ def fetch_quota(force=False, account=None):
                     return _keep_stale(str(exc), auth_required=True)
                 status, body = _http_get_usage(oauth["accessToken"])
             else:
-                # 429 / 5xx — keep last good bars instead of wiping the page.
-                return _keep_stale(f"HTTP Error {e.code}: {e.reason}")
+                # 429 / 5xx — keep last good bars instead of wiping the page,
+                # and let a Retry-After floor the backoff: it is the one wait
+                # the provider stated rather than one we guessed.
+                return _keep_stale(f"HTTP Error {e.code}: {e.reason}",
+                                   retry_after_s=_retry_after_s(e))
 
         if status != 200:
             return _keep_stale(f"usage HTTP {status}")
@@ -721,6 +740,10 @@ def reset_for_tests():
         _oauth_mem.clear()
     with _deny_lock:
         _keychain_denied.clear()
+    # Clear, not update: the cache also carries bookkeeping keys written on
+    # failure (fail_streak, retry_after_s, stale_since) that an update would
+    # leave behind, bleeding one test's outage into the next.
+    _cache.clear()
     _cache.update(t=0.0, data=None, err=None)
     _caches.clear()
     _caches[""] = _cache

--- a/host/test_cache_util.py
+++ b/host/test_cache_util.py
@@ -57,5 +57,86 @@ class KeepStaleTests(unittest.TestCase):
         self.assertEqual(later["stale_for_s"], 3600)
 
 
+class FailureBackoffTests(unittest.TestCase):
+    """A failure that keeps failing must stop being retried like a blip.
+
+    The shipped counterexample: three Claude accounts on a 20-second retry is
+    nine requests a minute at a rate-limited endpoint — a cadence that keeps
+    the 429 alive for as long as anyone lets it run.
+    """
+
+    TTL, FAIL = 60, 20
+
+    def _fail(self, cache, at):
+        cache_util.keep_stale(cache, at, "HTTP Error 429", EMPTY)
+
+    def test_first_failure_keeps_the_short_retry(self):
+        cache = {}
+        cache_util.store(cache, NOW, {"ok": True})
+        self._fail(cache, NOW + 60)
+        self.assertTrue(cache_util.fresh(
+            cache, NOW + 60 + self.FAIL - 1, self.TTL, self.FAIL))
+        self.assertFalse(cache_util.fresh(
+            cache, NOW + 60 + self.FAIL + 1, self.TTL, self.FAIL))
+
+    def test_consecutive_failures_double_the_wait(self):
+        cache = {}
+        cache_util.store(cache, NOW, {"ok": True})
+        at = NOW
+        for _ in range(3):
+            self._fail(cache, at)
+        # Third consecutive miss → 4 × FAIL before the next try.
+        self.assertTrue(cache_util.fresh(
+            cache, at + 4 * self.FAIL - 1, self.TTL, self.FAIL))
+        self.assertFalse(cache_util.fresh(
+            cache, at + 4 * self.FAIL + 1, self.TTL, self.FAIL))
+
+    def test_the_backoff_is_capped(self):
+        cache = {}
+        cache_util.store(cache, NOW, {"ok": True})
+        for _ in range(40):
+            self._fail(cache, NOW)
+        self.assertFalse(cache_util.fresh(
+            cache, NOW + cache_util.FAIL_BACKOFF_CAP_S + 1,
+            self.TTL, self.FAIL))
+
+    def test_a_good_fetch_resets_the_streak(self):
+        cache = {}
+        cache_util.store(cache, NOW, {"ok": True})
+        for _ in range(6):
+            self._fail(cache, NOW)
+        cache_util.store(cache, NOW + 600, {"ok": True})
+        self._fail(cache, NOW + 700)
+        # Back at the short leash, not the one the old outage earned.
+        self.assertFalse(cache_util.fresh(
+            cache, NOW + 700 + self.FAIL + 1, self.TTL, self.FAIL))
+
+    def test_retry_after_floors_the_wait_and_is_capped(self):
+        cache = {}
+        cache_util.store(cache, NOW, {"ok": True})
+        cache_util.keep_stale(cache, NOW, "HTTP Error 429", EMPTY,
+                              retry_after_s=300)
+        # First failure would retry at FAIL; the provider said 300s.
+        self.assertTrue(cache_util.fresh(
+            cache, NOW + 299, self.TTL, self.FAIL))
+        self.assertFalse(cache_util.fresh(
+            cache, NOW + 301, self.TTL, self.FAIL))
+        # A garbage header cannot park the source for a day.
+        cache_util.keep_stale(cache, NOW, "HTTP Error 429", EMPTY,
+                              retry_after_s=86_400)
+        self.assertFalse(cache_util.fresh(
+            cache, NOW + cache_util.RETRY_AFTER_CAP_S + 1,
+            self.TTL, self.FAIL))
+
+    def test_force_ignores_the_backoff(self):
+        # Refresh all is a human at the wheel; the backoff is for the poller.
+        cache = {}
+        cache_util.store(cache, NOW, {"ok": True})
+        for _ in range(10):
+            self._fail(cache, NOW)
+        self.assertFalse(cache_util.fresh(
+            cache, NOW + 1, self.TTL, self.FAIL, force=True))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/host/test_stale_quota.py
+++ b/host/test_stale_quota.py
@@ -418,6 +418,22 @@ class AuthRequiredTests(unittest.TestCase):
         self.assertFalse(out["auth_required"])
         self.assertIn("429", out["error"])
 
+    def test_a_rate_limits_retry_after_reaches_the_backoff(self):
+        # The one wait that is not a guess. It has to land in the cache the
+        # retry TTL reads, or the fetcher keeps knocking on the provider's
+        # stated cooldown.
+        blob = {"claudeAiOauth": {"accessToken": "t", "refreshToken": "r"}}
+        boom = urllib.error.HTTPError(
+            oauth_usage.USAGE_URL, 429, "Too Many Requests",
+            {"Retry-After": "120"}, None)
+        with patch.object(oauth_usage, "_read_creds_blob",
+                          return_value=("keychain", blob)), \
+             patch.object(oauth_usage, "_http_get_usage", side_effect=boom):
+            oauth_usage.fetch_quota(force=True)
+        cache = oauth_usage._cache_for(None)
+        self.assertEqual(cache.get("retry_after_s"), 120.0)
+        self.assertEqual(cache.get("fail_streak"), 1)
+
     def test_the_flag_reaches_providers_and_sources(self):
         state = {"claude": quota_payload(
             stale=True, auth_required=True, error="no plan token")}


### PR DESCRIPTION
## What

A quota fetch that fails is retried every `FAIL_TTL_S` (20s) forever. Against a rate limit that cadence is self-sustaining: with three Claude accounts configured that is ~9 requests/minute to Anthropic's usage endpoint from one IP — observed live as all three Claude rings stuck on 17–20-hour-old numbers with every poll answering `HTTP 429`.

## How

- **Exponential backoff in `cache_util`**, so every fetcher gets it through the existing `fresh()` / `keep_stale()` pair: consecutive failures double the retry interval from `fail_ttl_s` up to a 15-minute cap. One good fetch resets the streak, so a recovered provider is back on the short leash immediately.
- **`Retry-After` is honored** on the Claude 429/5xx path: it floors the next retry (it is the one wait the provider stated rather than one we guessed), capped at an hour so a garbage header cannot park a source for a day.
- **`force` still bypasses everything** — Refresh all and the board's long-press behave exactly as before.
- `oauth_usage.reset_for_tests` now clears the failure bookkeeping (`fail_streak`, `retry_after_s`, `stale_since`) it used to leave behind, which was bleeding one test's outage into the next.

Nothing changes on the wire: `/usage` payloads, staleness flags and attention behavior are untouched; only the retry cadence moves.

## Tests

- `test_cache_util.FailureBackoffTests`: streak growth, the cap, reset-on-success, the `Retry-After` floor and its ceiling, and `force` bypass.
- `test_stale_quota`: a 429 carrying `Retry-After` lands in the cache the retry TTL reads.
- Full host suite: 437 tests, 3 pre-existing failures unrelated to this change (registry tests that read the developer's real `~/.headroom` accounts config; happy to fix separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)