### PR TITLE
feat(attention): say why a quota froze and whose move it is

### DIFF
--- a/host/headroom_server.py
+++ b/host/headroom_server.py
@@ -939,6 +939,32 @@ def _bodies():
         return _cache["usage"], _cache["device"]
 
 
+def _stale_cause(error):
+    """One clause naming why a quota froze and whether waiting fixes it.
+
+    The glossary splits staleness into things you wait out (rate limits,
+    outages — the host is already retrying) and things you go fix. The
+    attention line has to say which one this is, or "stuck at 17h old"
+    reads as equally mysterious either way.
+    """
+    text = str(error or "")
+    low = text.lower()
+    if "429" in low or "too many requests" in low:
+        return "provider is rate-limiting, retrying"
+    if ("http error 5" in low or "usage http 5" in low
+            or "bad gateway" in low or "service unavailable" in low):
+        return "provider error, retrying"
+    if any(mark in low for mark in (
+            "timed out", "timeout", "unreachable", "connection",
+            "getaddrinfo", "nodename", "network", "temporary failure")):
+        return "no route to provider — check network"
+    if text:
+        # An error nothing above recognizes is exactly the one worth
+        # showing verbatim, clipped to fit a menu-bar subtitle.
+        return text if len(text) <= 48 else text[:47] + "…"
+    return "no error recorded — try Refresh all"
+
+
 def _build_attention(doc):
     """Single glance score for menu-bar warning light + Overview card."""
     reasons = []
@@ -1035,7 +1061,12 @@ def _build_attention(doc):
         # meter reads plausibly and is not being refreshed by anyone, and no
         # amount of waiting fixes it — outranking stale for the same reason.
         if provider.get("auth_required"):
-            add("warn", "signin", f"{title} needs sign-in", 45)
+            add(
+                "warn",
+                "signin",
+                f"{title} needs sign-in — log in with the tool again",
+                45,
+            )
             continue
         held = provider.get("stale_for_s")
         if not provider.get("stale") or not isinstance(held, (int, float)):
@@ -1045,7 +1076,8 @@ def _build_attention(doc):
         add(
             "warn",
             "stale",
-            f"{title} quota stuck at {oauth_usage.fmt_resets(held)} old",
+            f"{title} quota stuck at {oauth_usage.fmt_resets(held)} old"
+            f" — {_stale_cause(provider.get('error'))}",
             30,
         )
 

--- a/host/test_stale_quota.py
+++ b/host/test_stale_quota.py
@@ -455,4 +455,34 @@ class AuthRequiredTests(unittest.TestCase):
         self.assertIn("signin", kinds)
         self.assertNotIn("stale", kinds)
         summary = next(r["summary"] for r in reasons if r["kind"] == "signin")
-        self.assertEqual(summary, "Claude needs sign-in")
+        self.assertEqual(
+            summary, "Claude needs sign-in — log in with the tool again")
+
+    def test_stale_attention_names_the_cause(self):
+        # "Stuck at 17h old" alone reads the same whether the fix is patience
+        # or a login — the line has to say which. The recorded error is on the
+        # provider row already; the reason phrases it.
+        def summary_for(error):
+            doc = {"providers": [{
+                "id": "claude", "title": "Claude", "kind": "quota",
+                "enabled": True, "ok": True, "stale": True,
+                "stale_for_s": cache_util.STALE_ALERT_S + 60,
+                "error": error,
+            }]}
+            reasons = headroom_server._build_attention(doc)["reasons"]
+            return next(
+                r["summary"] for r in reasons if r["kind"] == "stale")
+
+        self.assertIn(
+            "provider is rate-limiting, retrying",
+            summary_for("HTTP Error 429: Too Many Requests"))
+        self.assertIn(
+            "provider error, retrying",
+            summary_for("HTTP Error 503: Service Unavailable"))
+        self.assertIn(
+            "check network",
+            summary_for("<urlopen error [Errno 8] nodename nor servname "
+                        "provided, or not known>"))
+        # An unrecognized error shows verbatim rather than vanishing.
+        self.assertIn("keychain said no", summary_for("keychain said no"))
+        self.assertIn("try Refresh all", summary_for(None))


### PR DESCRIPTION
## What

A stale quota's attention line read `Claude · Personal quota stuck at 17h 44m old` — true, but it reads the same whether the fix is patience or a login. The glossary already splits staleness into things you wait out (rate limits, outages — the host is retrying) and things you go fix; the line now says which one this is.

- `… quota stuck at 17h 44m old — provider is rate-limiting, retrying` (429s; also the live case that motivated this, observed alongside #13)
- `… — provider error, retrying` (5xx)
- `… — no route to provider — check network` (timeouts, DNS, dropped VPN)
- An unrecognized error shows verbatim, clipped to fit a menu-bar subtitle; a missing error suggests **Refresh all**
- `Claude needs sign-in` gains its remedy: `— log in with the tool again`

## How

One helper, `_stale_cause` in `host/headroom_server.py`, phrasing the `error` field the provider row already carries. Host-side only — every client (menu bar, iOS, board) displays the summary verbatim, so nothing changes on the wire but the string. Weights, kinds, thresholds, and ack fingerprint behavior are untouched, per `docs/attention.md`.

## Tests

- `test_stale_attention_names_the_cause`: all five phrasings.
- The pinned sign-in summary assertion updated for the new remedy clause.
- Affected modules green (55 tests); glossary copy gate passes.

Independent of #13 (verified both merge orders locally) — the "retrying" wording stays truthful with or without the backoff, since the host retries either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)