### PR TITLE
Add Grok (xAI) subscription source via the Grok CLI's ACP interface

### DIFF
--- a/host/detect_sources.py
+++ b/host/detect_sources.py
@@ -14,6 +14,7 @@ import subprocess
 import app_config
 import copilot_usage
 import gemini_usage
+import grok_usage
 import jetbrains_usage
 import oauth_usage
 import windsurf_usage
@@ -160,6 +161,7 @@ PROBES = {
     "windsurf": windsurf_usage.signed_in,
     "jetbrains": jetbrains_usage.signed_in,
     "zed": zed_usage.signed_in,
+    "grok": grok_usage.signed_in,
     "vercel": vercel_signed_in,
     "git": git_available,
     "github": github_signed_in,

--- a/host/grok_usage.py
+++ b/host/grok_usage.py
@@ -142,12 +142,30 @@ def _map(blob):
     used = _num(config.get("onDemandUsed"))
     pct = quota_util.used_pct(used, cap) if cap else None
 
+    credits = quota_util.pool(pct, resets_in, WEEK_WINDOW_S)
+    if cap is not None:
+        if credits is None:
+            credits = {
+                "pct": pct,
+                "resets_in_s": resets_in,
+                "resets_in": oauth_usage.fmt_resets(resets_in),
+                "window_s": WEEK_WINDOW_S,
+            }
+        remaining = None
+        if used is not None:
+            remaining = round(max(0.0, cap - used), 2)
+        credits.update({
+            "used_usd": used,
+            "limit_usd": cap,
+            "remaining_usd": remaining,
+        })
+
     ok = bool(tier) or resets_in is not None
     return {
         "ok": ok,
         "plan": tier,
         "error": None if ok else "no Grok billing data",
-        "credits": quota_util.pool(pct, resets_in, WEEK_WINDOW_S),
+        "credits": credits,
         "week_resets_in_s": resets_in,
         "week_resets_in": oauth_usage.fmt_resets(resets_in),
         "prepaid_balance": _num(config.get("prepaidBalance")),

--- a/host/grok_usage.py
+++ b/host/grok_usage.py
@@ -1,0 +1,178 @@
+"""Grok Build (xAI) subscription info via the Grok CLI's ACP interface.
+
+Reads nothing from the network directly: spawns `grok agent stdio` (the
+official Agent Client Protocol mode of the Grok CLI) and asks it for the
+`_x.ai/billing` extension method. That reuses the CLI's own OAuth session
+in ~/.grok/auth.json, so there are no cookies or scraped endpoints here.
+
+xAI currently exposes: subscription tier (e.g. "SuperGrok"), the weekly
+usage period bounds, on-demand credit cap/used and prepaid balance. It does
+NOT expose a percent-used figure for the subscription window itself, so the
+only ring-worthy pool is on-demand credits (when a cap is configured).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import select
+import subprocess
+import time
+
+import cache_util
+import oauth_usage
+import quota_util
+
+CACHE_TTL_S = 240
+FAIL_TTL_S = 30
+DISK = "grok_quota"
+AUTH_NAME = "auth.json"
+WEEK_WINDOW_S = 7 * 86400
+ACP_TIMEOUT_S = 20
+
+_cache = {"t": 0.0, "data": None, "err": None}
+_EMPTY = {"ok": False, "plan": None, "credits": None}
+
+
+def _auth_path():
+    return os.path.expanduser(os.path.join("~/.grok", AUTH_NAME))
+
+
+def _binary():
+    for cand in ("~/.grok/bin/grok", "~/.local/bin/grok",
+                 "/usr/local/bin/grok", "/opt/homebrew/bin/grok"):
+        path = os.path.expanduser(cand)
+        if os.access(path, os.X_OK):
+            return path
+    return None
+
+
+def signed_in():
+    if _binary() is None:
+        return False
+    try:
+        with open(_auth_path()) as handle:
+            blob = json.load(handle)
+    except (OSError, json.JSONDecodeError, TypeError):
+        return False
+    if not isinstance(blob, dict):
+        return False
+    return any(isinstance(v, dict) and v.get("key") for v in blob.values())
+
+
+def _acp_billing(binary):
+    """One-shot ACP round-trip: initialize, `_x.ai/billing`, terminate."""
+    proc = subprocess.Popen(
+        [binary, "agent", "stdio"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        payload = (
+            json.dumps({
+                "jsonrpc": "2.0", "id": 1, "method": "initialize",
+                "params": {"protocolVersion": 1, "clientCapabilities": {}},
+            }) + "\n" +
+            json.dumps({
+                "jsonrpc": "2.0", "id": 2,
+                "method": "_x.ai/billing", "params": {},
+            }) + "\n"
+        ).encode("utf-8")
+        proc.stdin.write(payload)
+        proc.stdin.flush()
+
+        deadline = time.time() + ACP_TIMEOUT_S
+        buf = b""
+        fd = proc.stdout.fileno()
+        while time.time() < deadline:
+            ready, _, _ = select.select([fd], [], [], 0.5)
+            if not ready:
+                if proc.poll() is not None:
+                    break
+                continue
+            chunk = os.read(fd, 65536)
+            if not chunk:
+                break
+            buf += chunk
+            for line in buf.split(b"\n"):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    msg = json.loads(line)
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    continue
+                if msg.get("id") == 2:
+                    if "result" in msg:
+                        return msg["result"]
+                    err = msg.get("error") or {}
+                    raise RuntimeError(
+                        err.get("message") or "billing call failed")
+        raise RuntimeError("Grok CLI did not answer in time")
+    finally:
+        try:
+            proc.kill()
+        except OSError:
+            pass
+
+
+def _num(value):
+    """xAI wraps numbers as {"val": n}; accept both shapes."""
+    if isinstance(value, dict):
+        value = value.get("val")
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _map(blob):
+    config = blob.get("config") if isinstance(blob, dict) else None
+    if not isinstance(config, dict):
+        config = {}
+    tier = blob.get("subscription_tier") if isinstance(blob, dict) else None
+    period = config.get("currentPeriod")
+    if not isinstance(period, dict):
+        period = {}
+    resets_in = quota_util.resets_from_iso(
+        period.get("end") or config.get("billingPeriodEnd"))
+
+    cap = _num(config.get("onDemandCap"))
+    used = _num(config.get("onDemandUsed"))
+    pct = quota_util.used_pct(used, cap) if cap else None
+
+    ok = bool(tier) or resets_in is not None
+    return {
+        "ok": ok,
+        "plan": tier,
+        "error": None if ok else "no Grok billing data",
+        "credits": quota_util.pool(pct, resets_in, WEEK_WINDOW_S),
+        "week_resets_in_s": resets_in,
+        "week_resets_in": oauth_usage.fmt_resets(resets_in),
+        "prepaid_balance": _num(config.get("prepaidBalance")),
+        "stale": False,
+    }
+
+
+def fetch_quota(force=False):
+    now = time.time()
+    if cache_util.fresh(_cache, now, CACHE_TTL_S, FAIL_TTL_S, force):
+        return _cache["data"]
+
+    binary = _binary()
+    if binary is None or not signed_in():
+        return cache_util.keep_stale(
+            _cache, now, "not signed in to Grok CLI", _EMPTY, disk_name=DISK)
+
+    try:
+        blob = _acp_billing(binary)
+        out = _map(blob)
+        if out.get("ok"):
+            return cache_util.store(_cache, now, out, disk_name=DISK)
+        return cache_util.keep_stale(
+            _cache, now, out.get("error") or "Grok billing unavailable",
+            _EMPTY, disk_name=DISK)
+    except Exception as exc:  # noqa: BLE001
+        return cache_util.keep_stale(
+            _cache, now, str(exc), _EMPTY, disk_name=DISK)

--- a/host/sources_config.py
+++ b/host/sources_config.py
@@ -44,6 +44,7 @@ import detect_sources
 import gemini_usage
 import git_activity
 import github_actions
+import grok_usage
 import jetbrains_usage
 import local_servers
 import oauth_usage
@@ -482,6 +483,27 @@ _ZED_POOLS = (
     PoolSpec("predictions", "predictions", "Predictions",
              zed_usage.MONTH_WINDOW_S),
 )
+# xAI exposes no percent-used figure for the subscription window (only the
+# window bounds + on-demand credit cap/used), so the sole meter is on-demand
+# credits — dollars against a cap, same shape as Cursor's on-demand.
+_GROK_POOLS = (
+    PoolSpec("credits", "credits", "Credits", grok_usage.WEEK_WINDOW_S,
+             kind=KIND_OVERAGE, ring=False),
+)
+
+
+def _detail_grok(payload):
+    if not isinstance(payload, dict) or not payload.get("ok"):
+        return None
+    parts = []
+    if payload.get("plan"):
+        parts.append(str(payload["plan"]))
+    credits = payload.get("credits")
+    if isinstance(credits, dict) and credits.get("pct") is not None:
+        parts.append("credits {:.0f}%".format(credits["pct"]))
+    if payload.get("week_resets_in"):
+        parts.append("resets {}".format(payload["week_resets_in"]))
+    return " · ".join(parts) if parts else None
 
 BASE_SOURCES = (
     Source("claude", "Claude", "~/.headroom/oauth (imports Claude login)", 60,
@@ -534,6 +556,10 @@ BASE_SOURCES = (
            zed_usage.fetch_quota,
            kind="quota", group=GROUP_AI, pools=_ZED_POOLS,
            headline=("predictions",), accent="#084CCF"),
+    Source("grok", "Grok", "~/.grok/auth.json (Grok CLI)", 300,
+           grok_usage.fetch_quota, detail_fn=_detail_grok,
+           kind="quota", group=GROUP_AI, pools=_GROK_POOLS,
+           headline=("credits",), accent="#8E8E93"),
     # Non-quota rows are appended after quotas in ordered_sources(); keep this
     # with the other activity sources so SOURCE_IDS stays in rollup order.
     Source("claude-status", "Claude Status", "status.claude.com", 60,

--- a/host/sources_config.py
+++ b/host/sources_config.py
@@ -559,7 +559,7 @@ BASE_SOURCES = (
     Source("grok", "Grok", "~/.grok/auth.json (Grok CLI)", 300,
            grok_usage.fetch_quota, detail_fn=_detail_grok,
            kind="quota", group=GROUP_AI, pools=_GROK_POOLS,
-           headline=("credits",), accent="#8E8E93"),
+           accent="#8E8E93"),
     # Non-quota rows are appended after quotas in ordered_sources(); keep this
     # with the other activity sources so SOURCE_IDS stays in rollup order.
     Source("claude-status", "Claude Status", "status.claude.com", 60,

--- a/host/test_new_quota_providers.py
+++ b/host/test_new_quota_providers.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import copilot_usage
+import grok_usage
 import jetbrains_usage
 import quota_util
 import sources_config
@@ -23,15 +24,32 @@ class QuotaUtilTests(unittest.TestCase):
 
 
 class RegistryHasNewProviders(unittest.TestCase):
-    def test_eight_quota_sources(self):
+    def test_nine_quota_sources(self):
         ids = [s.id for s in sources_config.QUOTA_SOURCES]
         self.assertEqual(
             ids,
             ["claude", "codex", "cursor", "copilot", "gemini",
-             "windsurf", "jetbrains", "zed"],
+             "windsurf", "jetbrains", "zed", "grok"],
         )
         self.assertTrue(all(s.group == sources_config.GROUP_AI for s in
                             sources_config.QUOTA_SOURCES))
+
+
+class GrokMapTests(unittest.TestCase):
+    def test_maps_overage_as_dollars_without_a_burn_headline(self):
+        out = grok_usage._map({
+            "subscription_tier": "SuperGrok",
+            "config": {
+                "currentPeriod": {"end": "2099-08-01T00:00:00Z"},
+                "onDemandCap": {"val": 20},
+                "onDemandUsed": {"val": 5},
+            },
+        })
+        self.assertTrue(out["ok"])
+        self.assertEqual(out["credits"]["used_usd"], 5.0)
+        self.assertEqual(out["credits"]["limit_usd"], 20.0)
+        self.assertEqual(out["credits"]["remaining_usd"], 15.0)
+        self.assertIsNone(sources_config.headline_pct("grok", out))
 
 
 class JetBrainsParseTests(unittest.TestCase):

--- a/host/test_quota_registry.py
+++ b/host/test_quota_registry.py
@@ -252,7 +252,12 @@ class QuotaRegistryTests(unittest.TestCase):
         self.assertEqual(
             sources_config.BURN_SOURCE_IDS,
             tuple(s.id for s in sources_config.QUOTA_SOURCES))
-        self.assertEqual(quota_samples.PROVIDERS, sources_config.BURN_SOURCE_IDS)
+        self.assertEqual(
+            quota_samples.PROVIDERS,
+            tuple(source.id for source in sources_config.QUOTA_SOURCES
+                  if source.windows()),
+        )
+        self.assertNotIn("grok", quota_samples.PROVIDERS)
         self.assertTrue({"claude", "codex", "cursor"}.issubset(
             set(sources_config.BURN_SOURCE_IDS)))
         # Windows, not every meter. The sample store records percentages


### PR DESCRIPTION
## What

A new `grok` quota source: subscription tier (e.g. `SuperGrok`), weekly-window reset countdown, and on-demand credits as an `overage` meter. Detail line renders as `SuperGrok · resets 6d 6h`.

## How (no scraping, no cookies)

The Grok CLI ("Grok Build", `~/.grok/bin/grok`) speaks the Agent Client Protocol. The fetcher spawns a one-shot `grok agent stdio`, sends `initialize` followed by the extension method `_x.ai/billing`, and reads the JSON result — reusing the CLI's own OAuth session in `~/.grok/auth.json`. Same spirit as the existing codex-app-server adapter. Round-trip is ~1.2 s, polled at 300 s with the usual cache_util TTL/stale handling.

Example payload xAI returns:

```json
{
  "config": {
    "currentPeriod": {"type": "USAGE_PERIOD_TYPE_WEEKLY", "start": "…", "end": "…"},
    "onDemandCap": {"val": 0}, "onDemandUsed": {"val": 0},
    "prepaidBalance": {"val": 0}, "isUnifiedBillingUser": true
  },
  "subscription_tier": "SuperGrok"
}
```

xAI does **not** expose a percent-used figure for the subscription window itself, so the only meter is on-demand credits (`kind=overage`, `ring=False`, pct only when a cap is configured). If xAI ever ships a used-percent, it slots into the same fetcher.

## Why not HTTP directly

`auth.x.ai` is Cloudflare-gated for non-CLI clients (403), and grok.com cookie scraping is fragile by design (anti-bot headers; the known third-party trackers for it died that way). The ACP route avoids both.

## Changes

- new `host/grok_usage.py` — stdlib only, `signed_in()` + `fetch_quota(force=)`, cache_util/quota_util patterns
- `host/sources_config.py` — `_GROK_POOLS`, `_detail_grok`, one `Source("grok", …, poll_s=300, accent="#8E8E93")` row after zed
- `host/detect_sources.py` — `grok` probe (binary on PATH candidates + `auth.json` holds a key)

## Testing

- `host/test_contract.py`: 21/22 pass — the one failure (`test_rollup_order_follows_the_pinned_provider_order`, expects `focus[0] == "cursor"`) also fails on unmodified `main` on this machine (no Cursor installed), so it looks environment-dependent rather than related to this change. Happy to dig into it separately if useful.
- Live on macOS 15 / v1.4.2 host: `/health` shows `grok: ok · SuperGrok · resets 6d 6h`; `/usage` `providers[]` carries the row with accent/pools; menu bar + iPhone app render it from the feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)