### PR TITLE
fix: shut down the Grok CLI gracefully — SIGKILL can wipe its login

### DIFF
--- a/host/grok_usage.py
+++ b/host/grok_usage.py
@@ -111,8 +111,24 @@ def _acp_billing(binary):
                         err.get("message") or "billing call failed")
         raise RuntimeError("Grok CLI did not answer in time")
     finally:
+        # Never SIGKILL the CLI outright: `grok agent stdio` rotates
+        # ~/.grok/auth.json during startup, and a kill that lands mid-write
+        # deletes the login — observed twice in the wild as a vanished
+        # auth.json with its .lock file left behind, forcing a fresh
+        # `grok login`. Closing stdin signals EOF, which the agent treats
+        # as a clean shutdown; escalate only if it lingers.
         try:
-            proc.kill()
+            proc.stdin.close()
+        except OSError:
+            pass
+        try:
+            proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            proc.terminate()
+            try:
+                proc.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                proc.kill()
         except OSError:
             pass
 


### PR DESCRIPTION
Follow-up to #19 (the Grok source) with a bug I hit running it in production for a week.

## Symptom

Twice within five days the Grok source flipped to `not signed in to Grok CLI` and stayed there. Each time `~/.grok/auth.json` had vanished while its `auth.json.lock` was left orphaned — the classic footprint of a writer killed mid-rotation. The CLI itself then reports `You are not authenticated.` and the user has to run `grok login` again. (The first occurrence coincided with a CLI self-update, which masked the real cause for a while.)

## Mechanism

`_acp_billing()` spawns `grok agent stdio` and, in its `finally`, SIGKILLs the process the moment the billing answer arrives. The CLI rotates `auth.json` during startup (lock → rewrite). With a poll every 300 s, a kill eventually lands inside that window and the login file is gone. So the provider slowly logs its own users out of the Grok CLI.

## Fix

Close stdin instead — the agent treats EOF as a clean shutdown and exits well under a second in my measurements — then escalate `terminate` → `kill` only if it lingers past two 3 s timeouts. Poll cost is unchanged; the fetcher's total-deadline behavior (`ACP_TIMEOUT_S`) is untouched.

Running this patched on my machine since the last re-login: the login has survived every poll since, where the unpatched host lost it within ~2 days.

## Testing

`cd host && python3 -m unittest`: 646/648 — the two failures (`test_rollup_order_follows_the_pinned_provider_order`, `test_attention_calls_out_a_login_without_waiting_for_stale`) fail identically on unmodified `main` on this machine (Claude signed in, no Cursor), so they look environment-dependent rather than related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)