### PR TITLE
fix(widget): preserve updates across configuration migration

### DIFF
--- a/Shared/HeadroomCopy.swift
+++ b/Shared/HeadroomCopy.swift
@@ -15,43 +15,57 @@ enum HeadroomCopy {
     static let quotas = "Quotas"
     static let codingQuotas = "Coding quotas"
 
-    /// One provider's answer under the overview rings. The reset uses the
-    /// reader's local clock, but stays deliberately compact and English:
-    /// "Claude: on pace. reset Sun 1pm, 11% to spare."
-    static func quotaOverviewSummary(
-        provider: String,
-        overPace: Bool,
+    /// "Reset: 5d1h, Sun 1pm." — the two reset readings already available
+    /// to the overview, combined into the caption directly below one ring.
+    static func quotaOverviewReset(
+        duration: String?,
         resetEpoch: Double?,
-        deltaPct: Double?,
         timeZone: TimeZone = .autoupdatingCurrent
+    ) -> String? {
+        var readings: [String] = []
+        if let compact = duration?.filter({ !$0.isWhitespace }),
+           !compact.isEmpty {
+            readings.append(compact)
+        }
+        if let clock = quotaOverviewClock(
+            resetEpoch: resetEpoch, timeZone: timeZone
+        ) {
+            readings.append(clock)
+        }
+        guard !readings.isEmpty else { return nil }
+        return "Reset: \(readings.joined(separator: ", "))."
+    }
+
+    /// "11% to Spare" / "4% Over" — standalone ring-column slack. When a
+    /// fit has no signed distance yet, retain the pace state without a number.
+    static func quotaOverviewSlack(
+        overPace: Bool,
+        deltaPct: Double?
     ) -> String {
-        let pace = overPace ? "over pace" : "on pace"
-        var details: [String] = []
-
-        if let resetEpoch {
-            var calendar = Calendar(identifier: .gregorian)
-            calendar.timeZone = timeZone
-            let date = Date(timeIntervalSince1970: resetEpoch)
-            let components = calendar.dateComponents([.weekday, .hour], from: date)
-            if let weekday = components.weekday,
-               let hour = components.hour,
-               (1...7).contains(weekday) {
-                let weekdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
-                let clockHour = (hour + 11) % 12 + 1
-                let meridiem = hour < 12 ? "am" : "pm"
-                details.append("reset \(weekdays[weekday - 1]) \(clockHour)\(meridiem)")
-            }
+        guard let deltaPct, abs(deltaPct) >= 1 else {
+            return overPace ? "Over Pace" : "On Pace"
         }
+        let rounded = Int(abs(deltaPct).rounded())
+        return deltaPct > 0 ? "\(rounded)% to Spare" : "\(rounded)% Over"
+    }
 
-        if let deltaPct, abs(deltaPct) >= 1 {
-            let rounded = Int(abs(deltaPct).rounded())
-            details.append(
-                deltaPct > 0 ? "\(rounded)% to spare" : "\(rounded)% over")
-        }
-
-        let answer = "\(provider): \(pace)."
-        guard !details.isEmpty else { return answer }
-        return "\(answer) \(details.joined(separator: ", "))."
+    private static func quotaOverviewClock(
+        resetEpoch: Double?,
+        timeZone: TimeZone
+    ) -> String? {
+        guard let resetEpoch else { return nil }
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        let date = Date(timeIntervalSince1970: resetEpoch)
+        let components = calendar.dateComponents([.weekday, .hour], from: date)
+        guard let weekday = components.weekday,
+              let hour = components.hour,
+              (1...7).contains(weekday)
+        else { return nil }
+        let weekdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+        let clockHour = (hour + 11) % 12 + 1
+        let meridiem = hour < 12 ? "am" : "pm"
+        return "\(weekdays[weekday - 1]) \(clockHour)\(meridiem)"
     }
 
     static let activity = "Activity"

--- a/Shared/HeadroomCopy.swift
+++ b/Shared/HeadroomCopy.swift
@@ -296,10 +296,21 @@ enum HeadroomCopy {
 
     /// One mandatory small-widget reset row. Host durations are spaced for
     /// prose (`5d 2h`); the tile removes that internal whitespace (`5d2h`).
-    static func widgetReset(_ title: String, duration: String?) -> String {
+    static func widgetReset(
+        _ title: String,
+        duration: String?,
+        resetEpoch: Double? = nil,
+        timeZone: TimeZone = .autoupdatingCurrent
+    ) -> String {
         let compact = duration?.filter { !$0.isWhitespace }
         let reading = compact.flatMap { $0.isEmpty ? nil : $0 } ?? "—"
-        return "\(title) \(reading)"
+        var answer = "\(title): \(reading)"
+        if let clock = quotaOverviewClock(
+            resetEpoch: resetEpoch, timeZone: timeZone
+        ) {
+            answer += ", \(clock)"
+        }
+        return answer
     }
 
     /// "Empty Thu" — the forecast reaches zero before the pool renews.

--- a/Shared/HeadroomCopy.swift
+++ b/Shared/HeadroomCopy.swift
@@ -14,6 +14,46 @@ enum HeadroomCopy {
     static let summary = "Summary"
     static let quotas = "Quotas"
     static let codingQuotas = "Coding quotas"
+
+    /// One provider's answer under the overview rings. The reset uses the
+    /// reader's local clock, but stays deliberately compact and English:
+    /// "Claude: on pace. reset Sun 1pm, 11% to spare."
+    static func quotaOverviewSummary(
+        provider: String,
+        overPace: Bool,
+        resetEpoch: Double?,
+        deltaPct: Double?,
+        timeZone: TimeZone = .autoupdatingCurrent
+    ) -> String {
+        let pace = overPace ? "over pace" : "on pace"
+        var details: [String] = []
+
+        if let resetEpoch {
+            var calendar = Calendar(identifier: .gregorian)
+            calendar.timeZone = timeZone
+            let date = Date(timeIntervalSince1970: resetEpoch)
+            let components = calendar.dateComponents([.weekday, .hour], from: date)
+            if let weekday = components.weekday,
+               let hour = components.hour,
+               (1...7).contains(weekday) {
+                let weekdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+                let clockHour = (hour + 11) % 12 + 1
+                let meridiem = hour < 12 ? "am" : "pm"
+                details.append("reset \(weekdays[weekday - 1]) \(clockHour)\(meridiem)")
+            }
+        }
+
+        if let deltaPct, abs(deltaPct) >= 1 {
+            let rounded = Int(abs(deltaPct).rounded())
+            details.append(
+                deltaPct > 0 ? "\(rounded)% to spare" : "\(rounded)% over")
+        }
+
+        let answer = "\(provider): \(pace)."
+        guard !details.isEmpty else { return answer }
+        return "\(answer) \(details.joined(separator: ", "))."
+    }
+
     static let activity = "Activity"
     static let services = "Services"
     static let supabase = "Supabase"

--- a/Shared/HeadroomCopy.swift
+++ b/Shared/HeadroomCopy.swift
@@ -36,7 +36,7 @@ enum HeadroomCopy {
         return "Reset: \(readings.joined(separator: ", "))."
     }
 
-    /// "11% to Spare" / "4% Over" — standalone ring-column slack. When a
+    /// "11% to spare" / "4% over" — standalone ring-column slack. When a
     /// fit has no signed distance yet, retain the pace state without a number.
     static func quotaOverviewSlack(
         overPace: Bool,
@@ -46,7 +46,7 @@ enum HeadroomCopy {
             return overPace ? "Over Pace" : "On Pace"
         }
         let rounded = Int(abs(deltaPct).rounded())
-        return deltaPct > 0 ? "\(rounded)% to Spare" : "\(rounded)% Over"
+        return deltaPct > 0 ? "\(rounded)% to spare" : "\(rounded)% over"
     }
 
     private static func quotaOverviewClock(

--- a/Shared/HeadroomCopy.swift
+++ b/Shared/HeadroomCopy.swift
@@ -271,6 +271,23 @@ enum HeadroomCopy {
         "\(Int(percent.rounded()))% left"
     }
 
+    /// The medium widget's compact pace reading. The slot is deliberate even
+    /// when an older cache has no pace value: losing the words would make the
+    /// legend jump between layouts and hide that the reading is unavailable.
+    static func widgetPaceSlack(_ deltaPct: Double?) -> String {
+        guard let deltaPct else { return "— to spare" }
+        let rounded = Int(abs(deltaPct).rounded())
+        return deltaPct >= 0 ? "\(rounded)% to spare" : "\(rounded)% over"
+    }
+
+    /// One mandatory small-widget reset row. Host durations are spaced for
+    /// prose (`5d 2h`); the tile removes that internal whitespace (`5d2h`).
+    static func widgetReset(_ title: String, duration: String?) -> String {
+        let compact = duration?.filter { !$0.isWhitespace }
+        let reading = compact.flatMap { $0.isEmpty ? nil : $0 } ?? "—"
+        return "\(title) \(reading)"
+    }
+
     /// "Empty Thu" — the forecast reaches zero before the pool renews.
     ///
     /// The counterpart to `resets(_:)`, and the one that outranks it wherever

--- a/Shared/HeadroomCopy.swift
+++ b/Shared/HeadroomCopy.swift
@@ -294,6 +294,15 @@ enum HeadroomCopy {
         return deltaPct >= 0 ? "\(rounded)% to spare" : "\(rounded)% over"
     }
 
+    #if os(macOS)
+    /// The Mac widget saves one word inside its single-line provider summary.
+    static func macWidgetPaceSlack(_ deltaPct: Double?) -> String {
+        guard let deltaPct else { return "— spare" }
+        let rounded = Int(abs(deltaPct).rounded())
+        return deltaPct >= 0 ? "\(rounded)% spare" : "\(rounded)% over"
+    }
+    #endif
+
     /// One mandatory small-widget reset row. Host durations are spaced for
     /// prose (`5d 2h`); the tile removes that internal whitespace (`5d2h`).
     static func widgetReset(

--- a/Shared/WidgetCacheWriter.swift
+++ b/Shared/WidgetCacheWriter.swift
@@ -36,10 +36,23 @@ enum HeadroomWidgetCache {
         // Same three the menu bar draws — the host picked them.
         let providers = snapshot.focusProviders()
             .map { provider in
-                let percent = provider.pools?.values
-                    .filter { $0.ring != false }
-                    .compactMap(\.pct)
-                    .max() ?? 0
+                let burndownRings = snapshot.burndownRings(
+                    forProviderID: provider.id
+                )
+                let ringLayers = provider.ringLayers(burndown: burndownRings)
+                let bindingPool = provider.visiblePools
+                    .compactMap { entry -> (id: String, percent: Double, pace: Double?)? in
+                        guard let percent = entry.pool.pct else { return nil }
+                        let sampledPace = burndownRings.first {
+                            $0.pool == entry.id
+                        }?.pacePercent
+                        return (entry.id, percent, sampledPace ?? entry.pool.pacePct)
+                    }
+                    .max { $0.percent < $1.percent }
+                let percent = bindingPool?.percent ?? 0
+                let paceDeltaPct = bindingPool.flatMap { pool in
+                    pool.pace.map { $0 - pool.percent }
+                }
                 return HeadroomWidgetSnapshot.Provider(
                     id: provider.id,
                     title: provider.markTitle,
@@ -48,17 +61,17 @@ enum HeadroomWidgetCache {
                     // ask, and VoiceOver needs the full name there.
                     name: provider.displayTitle,
                     percent: percent,
+                    paceDeltaPct: paceDeltaPct,
+                    sessionResetsIn: provider.pools?["session"]?.resetsIn,
+                    weekResetsIn: provider.pools?["week"]?.resetsIn,
                     accent: provider.accent,
-                    layers: provider.ringLayers(
-                        burndown: snapshot.burndownRings(
-                            forProviderID: provider.id
-                        )
-                    ).map {
+                    layers: ringLayers.map {
                         HeadroomWidgetSnapshot.Provider.Layer(
                             id: $0.id,
                             name: $0.name,
                             percent: $0.percent,
-                            pacePercent: $0.pacePercent
+                            pacePercent: $0.pacePercent,
+                            resetsIn: provider.pools?[$0.id]?.resetsIn
                         )
                     },
                     burndown: series(

--- a/Shared/WidgetCacheWriter.swift
+++ b/Shared/WidgetCacheWriter.swift
@@ -64,6 +64,9 @@ enum HeadroomWidgetCache {
                     paceDeltaPct: paceDeltaPct,
                     sessionResetsIn: provider.pools?["session"]?.resetsIn,
                     weekResetsIn: provider.pools?["week"]?.resetsIn,
+                    weekResetsAt: burndownRings.first {
+                        $0.pool == "week"
+                    }?.windowEnd,
                     accent: provider.accent,
                     layers: ringLayers.map {
                         HeadroomWidgetSnapshot.Provider.Layer(

--- a/Shared/WidgetCacheWriter.swift
+++ b/Shared/WidgetCacheWriter.swift
@@ -40,6 +40,12 @@ enum HeadroomWidgetCache {
                     forProviderID: provider.id
                 )
                 let ringLayers = provider.ringLayers(burndown: burndownRings)
+                let headlineBurndown = snapshot.overviewBurndown(
+                    forProviderID: provider.id
+                )
+                let headlinePoolID =
+                    headlineBurndown?.pool
+                    ?? snapshot.meter(for: provider).headline.id
                 let bindingPool = provider.visiblePools
                     .compactMap { entry -> (id: String, percent: Double, pace: Double?)? in
                         guard let percent = entry.pool.pct else { return nil }
@@ -48,10 +54,13 @@ enum HeadroomWidgetCache {
                         }?.pacePercent
                         return (entry.id, percent, sampledPace ?? entry.pool.pacePct)
                     }
-                    .max { $0.percent < $1.percent }
+                    .first { $0.id == headlinePoolID }
                 let percent = bindingPool?.percent ?? 0
                 let paceDeltaPct = bindingPool.flatMap { pool in
-                    pool.pace.map { $0 - pool.percent }
+                    if let pace = pool.pace {
+                        return pace - pool.percent
+                    }
+                    return headlineBurndown?.deltaPct
                 }
                 return HeadroomWidgetSnapshot.Provider(
                     id: provider.id,

--- a/Shared/WidgetIdentity.swift
+++ b/Shared/WidgetIdentity.swift
@@ -1,0 +1,9 @@
+/// Stable WidgetKit identities.
+///
+/// A widget kind is serialized into every placed tile. WidgetKit cannot
+/// migrate a tile between configuration systems, so the legacy static widget
+/// and the configurable widget must never share one.
+enum HeadroomWidgetIdentity {
+    static let legacyKind = "HeadroomWidget"
+    static let configurableKind = "HeadroomWidget.Configurable"
+}

--- a/Shared/WidgetIdentity.swift
+++ b/Shared/WidgetIdentity.swift
@@ -1,0 +1,9 @@
+/// Stable WidgetKit identities.
+///
+/// A widget kind is serialized into every placed tile. WidgetKit cannot
+/// migrate a tile between configuration systems, so the legacy static widget
+/// and the editable widget must never share one.
+enum HeadroomWidgetIdentity {
+    static let legacyKind = "HeadroomWidget"
+    static let editableKind = "HeadroomWidget.Configurable"
+}

--- a/Shared/WidgetSnapshot.swift
+++ b/Shared/WidgetSnapshot.swift
@@ -150,6 +150,9 @@ struct HeadroomWidgetSnapshot: Codable, Sendable {
         /// percentage worth drawing. Optional for older caches.
         var sessionResetsIn: String?
         var weekResetsIn: String?
+        /// Absolute weekly reset for the small widget's local weekday/clock.
+        /// Optional so caches written before the clock was added still decode.
+        var weekResetsAt: Double?
         var accent: String?
         /// Optional so widgets can still decode a cache written by an older app.
         var layers: [Layer]?
@@ -165,6 +168,7 @@ struct HeadroomWidgetSnapshot: Codable, Sendable {
             paceDeltaPct: Double? = nil,
             sessionResetsIn: String? = nil,
             weekResetsIn: String? = nil,
+            weekResetsAt: Double? = nil,
             accent: String? = nil,
             layers: [Layer]? = nil,
             burndown: Series? = nil
@@ -176,6 +180,7 @@ struct HeadroomWidgetSnapshot: Codable, Sendable {
             self.paceDeltaPct = paceDeltaPct
             self.sessionResetsIn = sessionResetsIn
             self.weekResetsIn = weekResetsIn
+            self.weekResetsAt = weekResetsAt
             self.accent = accent
             self.layers = layers
             self.burndown = burndown
@@ -197,6 +202,8 @@ struct HeadroomWidgetSnapshot: Codable, Sendable {
                 String.self, forKey: .sessionResetsIn)
             weekResetsIn = try row.decodeIfPresent(
                 String.self, forKey: .weekResetsIn)
+            weekResetsAt = try row.decodeIfPresent(
+                Double.self, forKey: .weekResetsAt)
             accent = try row.decodeIfPresent(String.self, forKey: .accent)
             layers = try row.decodeLossyArrayIfPresent(
                 Layer.self, forKey: .layers)
@@ -324,6 +331,9 @@ struct HeadroomWidgetSnapshot: Codable, Sendable {
                 paceDeltaPct: 11,
                 sessionResetsIn: "1h 34m",
                 weekResetsIn: "5d 2h",
+                weekResetsAt: Date.now.addingTimeInterval(
+                    5 * 24 * 60 * 60 + 2 * 60 * 60
+                ).timeIntervalSince1970,
                 accent: "#D97757",
                 layers: [
                     Provider.Layer(
@@ -347,6 +357,9 @@ struct HeadroomWidgetSnapshot: Codable, Sendable {
                 paceDeltaPct: 7,
                 sessionResetsIn: "2h 18m",
                 weekResetsIn: "5d 13h",
+                weekResetsAt: Date.now.addingTimeInterval(
+                    5 * 24 * 60 * 60 + 13 * 60 * 60
+                ).timeIntervalSince1970,
                 accent: "#10A37F",
                 layers: [
                     Provider.Layer(

--- a/Shared/WidgetSnapshot.swift
+++ b/Shared/WidgetSnapshot.swift
@@ -79,6 +79,9 @@ struct HeadroomWidgetSnapshot: Codable, Sendable {
             var name: String?
             var percent: Double?
             var pacePercent: Double?
+            /// Compact countdown source for the small widget. Optional for
+            /// caches written before reset rows existed.
+            var resetsIn: String?
         }
 
         /// One provider's line on the combined burndown: what is left against
@@ -138,6 +141,15 @@ struct HeadroomWidgetSnapshot: Codable, Sendable {
         /// and `title` is the closest thing it holds.
         var name: String?
         var percent: Double
+        /// Percentage points between this provider's binding quota and its
+        /// ideal pace. Optional so an older cache still decodes; the widget
+        /// presents absence as an explicit unknown reading.
+        var paceDeltaPct: Double?
+        /// Reset countdowns live at provider scope rather than only on ring
+        /// layers: a provider can know when a pool resets before it has a
+        /// percentage worth drawing. Optional for older caches.
+        var sessionResetsIn: String?
+        var weekResetsIn: String?
         var accent: String?
         /// Optional so widgets can still decode a cache written by an older app.
         var layers: [Layer]?
@@ -150,6 +162,9 @@ struct HeadroomWidgetSnapshot: Codable, Sendable {
             title: String,
             name: String? = nil,
             percent: Double = 0,
+            paceDeltaPct: Double? = nil,
+            sessionResetsIn: String? = nil,
+            weekResetsIn: String? = nil,
             accent: String? = nil,
             layers: [Layer]? = nil,
             burndown: Series? = nil
@@ -158,6 +173,9 @@ struct HeadroomWidgetSnapshot: Codable, Sendable {
             self.title = title
             self.name = name
             self.percent = percent
+            self.paceDeltaPct = paceDeltaPct
+            self.sessionResetsIn = sessionResetsIn
+            self.weekResetsIn = weekResetsIn
             self.accent = accent
             self.layers = layers
             self.burndown = burndown
@@ -173,6 +191,12 @@ struct HeadroomWidgetSnapshot: Codable, Sendable {
             name = try row.decodeIfPresent(String.self, forKey: .name)
             percent = try row.decodeIfPresent(
                 Double.self, forKey: .percent) ?? 0
+            paceDeltaPct = try row.decodeIfPresent(
+                Double.self, forKey: .paceDeltaPct)
+            sessionResetsIn = try row.decodeIfPresent(
+                String.self, forKey: .sessionResetsIn)
+            weekResetsIn = try row.decodeIfPresent(
+                String.self, forKey: .weekResetsIn)
             accent = try row.decodeIfPresent(String.self, forKey: .accent)
             layers = try row.decodeLossyArrayIfPresent(
                 Layer.self, forKey: .layers)
@@ -297,15 +321,20 @@ struct HeadroomWidgetSnapshot: Codable, Sendable {
                 title: "Claude",
                 name: "Claude",
                 percent: 42,
+                paceDeltaPct: 11,
+                sessionResetsIn: "1h 34m",
+                weekResetsIn: "5d 2h",
                 accent: "#D97757",
                 layers: [
                     Provider.Layer(
                         id: "session", name: "Session",
-                        percent: 42, pacePercent: 35
+                        percent: 42, pacePercent: 53,
+                        resetsIn: "1h 34m"
                     ),
                     Provider.Layer(
-                        id: "weekly", name: "Weekly",
-                        percent: 28, pacePercent: 31
+                        id: "week", name: "Weekly",
+                        percent: 28, pacePercent: 31,
+                        resetsIn: "5d 2h"
                     ),
                 ],
                 burndown: demoBurndown(remaining: 72, perDay: 16)
@@ -315,15 +344,20 @@ struct HeadroomWidgetSnapshot: Codable, Sendable {
                 title: "Codex",
                 name: "Codex",
                 percent: 28,
+                paceDeltaPct: 7,
+                sessionResetsIn: "2h 18m",
+                weekResetsIn: "5d 13h",
                 accent: "#10A37F",
                 layers: [
                     Provider.Layer(
                         id: "session", name: "Session",
-                        percent: 28, pacePercent: 35
+                        percent: 28, pacePercent: 35,
+                        resetsIn: "2h 18m"
                     ),
                     Provider.Layer(
-                        id: "weekly", name: "Weekly",
-                        percent: 18, pacePercent: 31
+                        id: "week", name: "Weekly",
+                        percent: 18, pacePercent: 31,
+                        resetsIn: "5d 13h"
                     ),
                 ],
                 burndown: demoBurndown(remaining: 82, perDay: 9)

--- a/Shared/WidgetSnapshotPresentation.swift
+++ b/Shared/WidgetSnapshotPresentation.swift
@@ -37,7 +37,7 @@ extension HeadroomWidgetSnapshot.Provider {
 
     /// Both rows are structural in the small widget. Missing layers and
     /// older caches keep their labels and show an explicit unknown countdown.
-    var widgetResetLabels: [String] {
+    func widgetResetLabels(in timeZone: TimeZone) -> [String] {
         // The layer fallback reads the first cache shape used while this field
         // was introduced; current writers keep resets independently of rings.
         let sessionReset = sessionResetsIn
@@ -46,8 +46,17 @@ extension HeadroomWidgetSnapshot.Provider {
             ?? layers?.first { $0.id == "week" }?.resetsIn
         return [
             HeadroomCopy.widgetReset("5h", duration: sessionReset),
-            HeadroomCopy.widgetReset("Weekly", duration: weeklyReset),
+            HeadroomCopy.widgetReset(
+                "1w",
+                duration: weeklyReset,
+                resetEpoch: weekResetsAt,
+                timeZone: timeZone
+            ),
         ]
+    }
+
+    var widgetResetLabels: [String] {
+        widgetResetLabels(in: .autoupdatingCurrent)
     }
 
     var ringLayers: [HeadroomRingLayer] {

--- a/Shared/WidgetSnapshotPresentation.swift
+++ b/Shared/WidgetSnapshotPresentation.swift
@@ -35,8 +35,35 @@ extension HeadroomWidgetSnapshot.Provider {
         HeadroomCopy.widgetPaceSlack(paceDeltaPct)
     }
 
-    /// Both rows are structural in the small widget. Missing layers and
-    /// older caches keep their labels and show an explicit unknown countdown.
+    #if os(macOS)
+    /// The Mac medium widget's only text row for this provider. Keeping
+    /// identity, quota and pace together buys the chart the height separate
+    /// rows spent without changing the iPhone widget's established layout.
+    var macWidgetMediumSummaryLabel: String {
+        let remaining = HeadroomCopy.percentLeft(100 - percent)
+        let pace = HeadroomCopy.macWidgetPaceSlack(paceDeltaPct)
+        return "\(title): \(remaining), \(pace)"
+    }
+
+    /// Mac small widgets only spend height on provider-specific reset clocks.
+    /// The shared pair remains intact for the iPhone widget and watch cache.
+    func macWidgetResetLabels(in timeZone: TimeZone) -> [String] {
+        let labels = widgetResetLabels(in: timeZone)
+        let baseID = id.split(separator: ":", maxSplits: 1)
+            .first.map(String.init)
+        if baseID == "claude" { return Array(labels.prefix(1)) }
+        if baseID == "codex" { return [] }
+        return labels
+    }
+
+    var macWidgetResetLabels: [String] {
+        macWidgetResetLabels(in: .autoupdatingCurrent)
+    }
+    #endif
+
+    /// Both rows are structural in the shared small-widget presentation.
+    /// Missing layers and older caches keep their labels and show an explicit
+    /// unknown countdown.
     func widgetResetLabels(in timeZone: TimeZone) -> [String] {
         // The layer fallback reads the first cache shape used while this field
         // was introduced; current writers keep resets independently of rings.

--- a/Shared/WidgetSnapshotPresentation.swift
+++ b/Shared/WidgetSnapshotPresentation.swift
@@ -29,6 +29,27 @@ extension HeadroomWidgetSnapshot.Provider {
     /// than the `name` key wrote, and the same string it already draws.
     var spokenTitle: String { name ?? title }
 
+    /// Always present in the medium widget's legend. An older cache provides
+    /// no value, but still gets the required unknown-state copy.
+    var widgetPaceSlackLabel: String {
+        HeadroomCopy.widgetPaceSlack(paceDeltaPct)
+    }
+
+    /// Both rows are structural in the small widget. Missing layers and
+    /// older caches keep their labels and show an explicit unknown countdown.
+    var widgetResetLabels: [String] {
+        // The layer fallback reads the first cache shape used while this field
+        // was introduced; current writers keep resets independently of rings.
+        let sessionReset = sessionResetsIn
+            ?? layers?.first { $0.id == "session" }?.resetsIn
+        let weeklyReset = weekResetsIn
+            ?? layers?.first { $0.id == "week" }?.resetsIn
+        return [
+            HeadroomCopy.widgetReset("5h", duration: sessionReset),
+            HeadroomCopy.widgetReset("Weekly", duration: weeklyReset),
+        ]
+    }
+
     var ringLayers: [HeadroomRingLayer] {
         if let layers, !layers.isEmpty {
             return layers.map {

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -447,6 +447,18 @@ computes its own top-N. Drag to reorder under Mac Settings → Providers.
 
 Say **top 3** in user-facing copy, not "focus" — that word is API vocabulary.
 
+### Widgets
+
+The medium widget names each provider with both remaining quota and pace:
+**84% left · 11% to spare**. Use **N% over** when the signed pace slack is
+negative. The pace slot is always present; a cache written before that reading
+existed shows **— to spare** rather than dropping the words.
+
+The small widget always gives each provider two reset rows: **5h 1h34m** and
+**Weekly 5d2h**. Widget durations remove internal spaces to fit the tile. A
+missing or older-cache reading keeps the row as **5h —** or **Weekly —**;
+neither reset row is conditional.
+
 ### Menu bar icon
 
 Mac Settings → General → **Menu bar icon** picks the glyph’s reading. Same

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -460,10 +460,11 @@ The medium widget names each provider with both remaining quota and pace:
 negative. The pace slot is always present; a cache written before that reading
 existed shows **— to spare** rather than dropping the words.
 
-The small widget always gives each provider two reset rows: **5h 1h34m** and
-**Weekly 5d2h**. Widget durations remove internal spaces to fit the tile. A
-missing or older-cache reading keeps the row as **5h —** or **Weekly —**;
-neither reset row is conditional.
+The small widget always gives each provider two reset rows: **5h: 1h34m** and
+**1w: 5d2h, Sun 1pm**. Widget durations remove internal spaces to fit the tile;
+the weekly row adds the reset weekday and local hour when the cache carries
+that instant. A missing or older-cache reading keeps the row as **5h: —** or
+**1w: —**; neither reset row is conditional.
 
 ### Menu bar icon
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -455,16 +455,18 @@ Say **top 3** in user-facing copy, not "focus" — that word is API vocabulary.
 
 ### Widgets
 
-The medium widget names each provider with both remaining quota and pace:
-**84% left · 11% to spare**. Use **N% over** when the signed pace slack is
-negative. The pace slot is always present; a cache written before that reading
-existed shows **— to spare** rather than dropping the words.
+The Mac medium widget gives each provider one line with identity, remaining
+quota and pace: **Claude: 89% left, 33% spare**. Use **N% over** when the signed
+pace slack is negative. The pace slot is always present; a cache written before
+that reading existed shows **— spare** rather than dropping the words. It never
+adds a separate **N% used** line.
 
-The small widget always gives each provider two reset rows: **5h: 1h34m** and
-**1w: 5d2h, Sun 1pm**. Widget durations remove internal spaces to fit the tile;
-the weekly row adds the reset weekday and local hour when the cache carries
-that instant. A missing or older-cache reading keeps the row as **5h: —** or
-**1w: —**; neither reset row is conditional.
+The Mac small widget gives Claude one reset row: **5h: 1h34m**. Codex gets no
+reset rows; its rings and percent are enough for this surface. Other providers
+keep the original **5h** and **1w** rows. Widget durations remove internal
+spaces to fit the tile, and a missing Claude reading stays visible as
+**5h: —**. These density exceptions are Mac-only; the iPhone widget keeps the
+shared two-row reset and three-row medium presentations.
 
 ### Menu bar icon
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -58,17 +58,23 @@ is stated as a noun.
 | Form | Looks like | Where | Field |
 |---|---|---|---|
 | Clock | `Thu 14:00`, `tomorrow 04:18` | `headline`, anywhere with a full line | `_when()` |
-| Quota overview clock | `Sun 1pm` | Per-provider sentence under the macOS rings | `window_end` |
+| Quota overview reset | `Reset: 5d1h, Sun 1pm.` | Per-provider caption under the macOS rings | `resets_in` + `window_end` |
 | Duration | `4d 44m`, `3d` | menu bar, watch, board, `Resets 3d` captions | `resets_in`, `fmt_resets()` |
 
-One sentence gets one form. `58% left · 4d 44m. Out tomorrow 04:18` was two
+One sentence usually gets one form. `58% left · 4d 44m. Out tomorrow 04:18` was two
 time facts in two shapes on one line. The board's `verdict` is the documented
 exception — at ~25 bytes it takes duration form, and each of its branches
 returns only one time fact, so the two never meet.
 
+The macOS quota overview is the other deliberate exception: its ring caption
+puts the compact countdown and local clock together as
+**Reset: 5d1h, Sun 1pm.**, followed by signed slack on its own line:
+**11% to Spare** or **4% Over**.
+
 **Host prose times are 24-hour, English (U.S.), not localized.** The macOS
-quota overview is the deliberate exception: its compact provider sentences use
-an unpadded 12-hour clock with lowercase `am` / `pm`, as in `reset Sun 1pm`.
+quota overview is the deliberate exception: its compact ring captions use
+an unpadded 12-hour clock with lowercase `am` / `pm`, as in
+`Reset: 5d1h, Sun 1pm.`.
 Every string is a literal; there is no `.strings` catalogue and
 `host/burndown.py` formats with `%H:%M`. The host form was decided by default
 rather than on purpose — record it here so the day

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -58,6 +58,7 @@ is stated as a noun.
 | Form | Looks like | Where | Field |
 |---|---|---|---|
 | Clock | `Thu 14:00`, `tomorrow 04:18` | `headline`, anywhere with a full line | `_when()` |
+| Quota overview clock | `Sun 1pm` | Per-provider sentence under the macOS rings | `window_end` |
 | Duration | `4d 44m`, `3d` | menu bar, watch, board, `Resets 3d` captions | `resets_in`, `fmt_resets()` |
 
 One sentence gets one form. `58% left · 4d 44m. Out tomorrow 04:18` was two
@@ -65,9 +66,12 @@ time facts in two shapes on one line. The board's `verdict` is the documented
 exception — at ~25 bytes it takes duration form, and each of its branches
 returns only one time fact, so the two never meet.
 
-**Times are 24-hour, English (U.S.), not localized.** Every string is a literal;
-there is no `.strings` catalogue and `host/burndown.py` formats with `%H:%M`.
-That was decided by default rather than on purpose — record it here so the day
+**Host prose times are 24-hour, English (U.S.), not localized.** The macOS
+quota overview is the deliberate exception: its compact provider sentences use
+an unpadded 12-hour clock with lowercase `am` / `pm`, as in `reset Sun 1pm`.
+Every string is a literal; there is no `.strings` catalogue and
+`host/burndown.py` formats with `%H:%M`. The host form was decided by default
+rather than on purpose — record it here so the day
 it changes is a decision and not a surprise.
 
 **Provider names belong to other companies.** Claude, Codex, Cursor, Copilot,

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -69,7 +69,7 @@ returns only one time fact, so the two never meet.
 The macOS quota overview is the other deliberate exception: its ring caption
 puts the compact countdown and local clock together as
 **Reset: 5d1h, Sun 1pm.**, followed by signed slack on its own line:
-**11% to Spare** or **4% Over**.
+**11% to spare** or **4% over**.
 
 **Host prose times are 24-hour, English (U.S.), not localized.** The macOS
 quota overview is the deliberate exception: its compact ring captions use

--- a/docs/ios-companion.md
+++ b/docs/ios-companion.md
@@ -54,18 +54,22 @@ Mac on its own — the phone forwards what it fetched. See
     holding a `burndown` key with no curve in it rendered as an empty tile
     with nothing to say why. The reading comes first now and the chart is
     added to it; `charted` tests for a stroke rather than for the key.
-  - **Edit Widget picks the provider** (`widget/HeadroomWidgetIntent.swift`).
+  - **A Provider widget can be edited to pick the provider**
+    (`widget/HeadroomWidgetIntent.swift`). The original **All providers**
+    widget remains a static definition so tiles placed before the picker was
+    introduced keep receiving timelines. WidgetKit stores a tile's
+    configuration system with its kind and cannot migrate that tile in place,
+    so the configurable widget deliberately has a new kind.
     The Providers pane still decides which providers exist and in what order,
     and the host still serves the top 3; the tile decides which of those it
     spends its space on, which is a question two tiles on one screen answer
     differently. A new tile starts on the provider closest to running out —
     the one every compact surface leads with — resolved once when the widget
     is added and stored with it, so a tile never wanders to a different
-    provider on its own. "All providers" is a choice rather than the landing
-    place, and it is still what every widget placed before the picker existed
-    keeps doing. A provider that leaves the top 3 leaves the tile drawing the
-    rest, never an empty box. App Intents
-    strings are literals in that file on purpose — the metadata extractor
+    provider on its own. "All providers" is a choice in the Provider widget
+    and is also what the compatibility widget keeps doing. A provider that
+    leaves the top 3 leaves the tile drawing the rest, never an empty box.
+    App Intents strings are literals in that file on purpose — the metadata extractor
     reads them out of the source at build time, so a `HeadroomCopy` constant
     would reach the picker as nothing.
 - Best-effort iOS background refresh.

--- a/docs/ios-companion.md
+++ b/docs/ios-companion.md
@@ -54,20 +54,30 @@ Mac on its own — the phone forwards what it fetched. See
     holding a `burndown` key with no curve in it rendered as an empty tile
     with nothing to say why. The reading comes first now and the chart is
     added to it; `charted` tests for a stroke rather than for the key.
-  - **Edit Widget picks the provider** (`widget/HeadroomWidgetIntent.swift`).
+  - **A Provider widget can be edited to pick the provider**
+    (`widget/HeadroomWidgetIntent.swift`). The original **All providers**
+    widget remains a static definition so tiles placed before the picker was
+    introduced keep receiving timelines. WidgetKit stores a tile's
+    configuration system with its kind and cannot migrate that tile in place,
+    so the editable widget deliberately has a new kind.
     The Providers pane still decides which providers exist and in what order,
     and the host still serves the top 3; the tile decides which of those it
     spends its space on, which is a question two tiles on one screen answer
     differently. A new tile starts on the provider closest to running out —
     the one every compact surface leads with — resolved once when the widget
     is added and stored with it, so a tile never wanders to a different
-    provider on its own. "All providers" is a choice rather than the landing
-    place, and it is still what every widget placed before the picker existed
-    keeps doing. A provider that leaves the top 3 leaves the tile drawing the
-    rest, never an empty box. App Intents
-    strings are literals in that file on purpose — the metadata extractor
-    reads them out of the source at build time, so a `HeadroomCopy` constant
-    would reach the picker as nothing.
+    provider on its own. "All providers" is a choice in the Provider widget
+    and is also what the compatibility widget keeps doing. A provider that
+    leaves the top 3 leaves the tile drawing the rest, never an empty box.
+    App Intents strings are literals in that file on purpose — the metadata
+    extractor reads them out of the source at build time, so a `HeadroomCopy`
+    constant would reach the picker as nothing.
+    - **One intermediate cohort cannot migrate in place.** Versions 2.0.6–2.1.0
+      briefly shipped the editable configuration under the original static
+      kind. A widget added in that window may freeze again when the static
+      definition is restored; remove it and add **Headroom — Provider** to
+      retain provider selection. There is no WidgetKit representation that
+      preserves both configuration systems under the same kind.
 - Best-effort iOS background refresh.
 - Pull-to-refresh, including the existing LAN-safe `POST /sync/refresh`.
 - iPhone and iPad layouts from one target.

--- a/macos/Sources/QuotaSection.swift
+++ b/macos/Sources/QuotaSection.swift
@@ -4,20 +4,33 @@ import SwiftUI
 /// detail card, and the attention summary.
 
 enum QuotaOverviewSummary {
-    static func lines(
+    struct Column: Identifiable, Equatable {
+        let providerID: String
+        let resetLine: String?
+        let paceLine: String
+
+        var id: String { providerID }
+    }
+
+    static func columns(
         for snapshot: UsageSnapshot,
         timeZone: TimeZone = .autoupdatingCurrent
-    ) -> [String] {
+    ) -> [Column] {
         snapshot.codingQuotaProviders.compactMap { provider in
             guard let burndown = snapshot.overviewBurndown(
                 forProviderID: provider.id
             ) else { return nil }
-            return HeadroomCopy.quotaOverviewSummary(
-                provider: provider.displayTitle,
-                overPace: burndown.kind != .ok,
-                resetEpoch: burndown.windowEnd,
-                deltaPct: burndown.deltaPct,
-                timeZone: timeZone
+            return Column(
+                providerID: provider.id,
+                resetLine: HeadroomCopy.quotaOverviewReset(
+                    duration: snapshot.meter(for: provider).headline.reset,
+                    resetEpoch: burndown.windowEnd,
+                    timeZone: timeZone
+                ),
+                paceLine: HeadroomCopy.quotaOverviewSlack(
+                    overPace: burndown.kind != .ok,
+                    deltaPct: burndown.deltaPct
+                )
             )
         }
     }
@@ -43,6 +56,13 @@ struct QuotaOverviewCard: View {
     private static let minimumRingCell: CGFloat = 54
 
     private var providers: [QuotaProviderInfo] { snapshot.codingQuotaProviders }
+
+    private var overviewColumns: [String: QuotaOverviewSummary.Column] {
+        Dictionary(
+            uniqueKeysWithValues: QuotaOverviewSummary.columns(for: snapshot)
+                .map { ($0.providerID, $0) }
+        )
+    }
 
     /// Columns that fit the measured width, balanced across however many rows
     /// that takes — six providers read as 3+3, not 5+1.
@@ -88,7 +108,8 @@ struct QuotaOverviewCard: View {
                             meter: snapshot.meter(for: provider),
                             rings: snapshot.burndownRings(forProviderID: provider.id),
                             tint: snapshot.tint(forProviderID: provider.id),
-                            diameter: ringDiameter
+                            diameter: ringDiameter,
+                            overview: overviewColumns[provider.id]
                         )
                         .frame(maxWidth: .infinity)
                         .contentShape(Rectangle())
@@ -96,17 +117,6 @@ struct QuotaOverviewCard: View {
                     }
                 }
                 .measuredWidth($rowWidth)
-            }
-            let summaries = QuotaOverviewSummary.lines(for: snapshot)
-            if !summaries.isEmpty {
-                VStack(alignment: .leading, spacing: 3) {
-                    ForEach(Array(summaries.enumerated()), id: \.offset) { _, summary in
-                        Text(summary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                }
-                .font(.caption)
-                .foregroundStyle(.secondary)
             }
         }
         .cardStyle()
@@ -310,6 +320,8 @@ struct ProviderQuotaRing: View {
     /// Set by the overview grid, which shrinks the glyph rather than let a
     /// row of them push past the popover.
     var diameter: CGFloat = 72
+    /// The reset and signed slack that belong directly under this ring.
+    var overview: QuotaOverviewSummary.Column? = nil
 
     private var headline: MeterWindow { meter.headline }
 
@@ -331,10 +343,9 @@ struct ProviderQuotaRing: View {
         ]
     }
 
-    /// The countdown is computed against the wall clock, so it keeps ticking
-    /// over numbers that stopped moving hours ago — the one part of this
-    /// glyph that actively insists a frozen meter is live. When the host says
-    /// the fetch is failing, the age of the data replaces it.
+    /// Fallback for an older host with no overview burndown. Current hosts use
+    /// the tested reset/slack column above; stale status remains a separate
+    /// line so it cannot erase those provider readings.
     private var windowCaption: String {
         if let note = provider.statusNote { return note }
         if provider.isBalanceOnly {
@@ -368,13 +379,38 @@ struct ProviderQuotaRing: View {
                 .foregroundStyle(tint)
                 .lineLimit(1)
                 .minimumScaleFactor(0.8)
-            Text(windowCaption)
-                .font(.caption2)
-                .foregroundStyle(
-                    provider.statusAlarming ? HeadroomPalette.orange : .secondary)
-                .monospacedDigit()
-                .lineLimit(1)
-                .minimumScaleFactor(0.85)
+            if let note = provider.statusNote {
+                Text(note)
+                    .font(.caption2)
+                    .foregroundStyle(
+                        provider.statusAlarming
+                            ? HeadroomPalette.orange : .secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
+            }
+            if let overview {
+                if let resetLine = overview.resetLine {
+                    Text(resetLine)
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                }
+                Text(overview.paceLine)
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            } else if provider.statusNote == nil {
+                Text(windowCaption)
+                    .font(.caption2)
+                    .foregroundStyle(
+                        provider.statusAlarming
+                            ? HeadroomPalette.orange : .secondary)
+                    .monospacedDigit()
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
+            }
         }
         .accessibilityElement(children: .combine)
         // The rings no longer carry a printed percentage, so state it here

--- a/macos/Sources/QuotaSection.swift
+++ b/macos/Sources/QuotaSection.swift
@@ -3,6 +3,26 @@ import SwiftUI
 /// The quota half of the popover: the ring overview, the single-provider
 /// detail card, and the attention summary.
 
+enum QuotaOverviewSummary {
+    static func lines(
+        for snapshot: UsageSnapshot,
+        timeZone: TimeZone = .autoupdatingCurrent
+    ) -> [String] {
+        snapshot.codingQuotaProviders.compactMap { provider in
+            guard let burndown = snapshot.overviewBurndown(
+                forProviderID: provider.id
+            ) else { return nil }
+            return HeadroomCopy.quotaOverviewSummary(
+                provider: provider.displayTitle,
+                overPace: burndown.kind != .ok,
+                resetEpoch: burndown.windowEnd,
+                deltaPct: burndown.deltaPct,
+                timeZone: timeZone
+            )
+        }
+    }
+}
+
 struct QuotaOverviewCard: View {
     let snapshot: UsageSnapshot
     /// Tapping a ring jumps to that provider's detail tab.
@@ -77,11 +97,16 @@ struct QuotaOverviewCard: View {
                 }
                 .measuredWidth($rowWidth)
             }
-            if let primary = snapshot.burndownPrimary, let headline = primary.headline {
-                Text(headline)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+            let summaries = QuotaOverviewSummary.lines(for: snapshot)
+            if !summaries.isEmpty {
+                VStack(alignment: .leading, spacing: 3) {
+                    ForEach(Array(summaries.enumerated()), id: \.offset) { _, summary in
+                        Text(summary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
             }
         }
         .cardStyle()

--- a/macos/Tests/ContractTests.swift
+++ b/macos/Tests/ContractTests.swift
@@ -187,8 +187,8 @@ final class ContractTests: XCTestCase {
         XCTAssertEqual(
             columns.map { [$0.resetLine ?? "", $0.paceLine] },
             [
-                ["Reset: 5d1h, Sun 1pm.", "11% to Spare"],
-                ["Reset: 5d10h, Mon 2am.", "7% to Spare"],
+                ["Reset: 5d1h, Sun 1pm.", "11% to spare"],
+                ["Reset: 5d10h, Mon 2am.", "7% to spare"],
             ]
         )
     }
@@ -201,7 +201,7 @@ final class ContractTests: XCTestCase {
                 overPace: true,
                 deltaPct: -4
             ),
-            "4% Over"
+            "4% over"
         )
     }
 
@@ -222,7 +222,7 @@ final class ContractTests: XCTestCase {
 
         XCTAssertEqual(
             QuotaOverviewSummary.columns(for: snapshot).first?.paceLine,
-            "4% Over"
+            "4% over"
         )
     }
 

--- a/macos/Tests/ContractTests.swift
+++ b/macos/Tests/ContractTests.swift
@@ -1091,11 +1091,13 @@ final class WidgetSnapshotSkewTests: XCTestCase {
                 "pools": {
                   "week": {
                     "title": "Weekly", "rank": 0, "pct": 16,
-                    "pace_pct": 27, "resets_in": "5d 2h", "ring": true
+                    "pace_pct": 27, "resets_in": "5d 2h",
+                    "window_s": 604800, "ring": true
                   },
                   "session": {
-                    "title": "Session", "rank": 1, "pct": 4,
-                    "pace_pct": 8, "resets_in": "1h 34m", "ring": true
+                    "title": "Session", "rank": 1, "pct": 44,
+                    "pace_pct": 53, "resets_in": "1h 34m",
+                    "window_s": 18000, "ring": true
                   }
                 }
               }],
@@ -1113,6 +1115,7 @@ final class WidgetSnapshotSkewTests: XCTestCase {
 
         let cached = HeadroomWidgetCache.save(usage)
         let provider = try XCTUnwrap(cached.providers.first)
+        XCTAssertEqual(provider.percent, 16)
         XCTAssertEqual(provider.paceDeltaPct, 11)
         XCTAssertEqual(provider.sessionResetsIn, "1h 34m")
         XCTAssertEqual(provider.weekResetsIn, "5d 2h")
@@ -1191,12 +1194,12 @@ final class WidgetSnapshotSkewTests: XCTestCase {
 
         let provider = try XCTUnwrap(
             HeadroomWidgetCache.save(usage).providers.first)
-        XCTAssertEqual(provider.percent, 80)
-        XCTAssertNil(provider.paceDeltaPct)
-        XCTAssertEqual(provider.widgetPaceSlackLabel, "— to spare")
+        XCTAssertEqual(provider.percent, 20)
+        XCTAssertEqual(provider.paceDeltaPct, 10)
+        XCTAssertEqual(provider.widgetPaceSlackLabel, "10% to spare")
         XCTAssertEqual(
             provider.macWidgetMediumSummaryLabel,
-            "Claude: 20% left, — spare"
+            "Claude: 80% left, 10% spare"
         )
     }
 

--- a/macos/Tests/ContractTests.swift
+++ b/macos/Tests/ContractTests.swift
@@ -971,6 +971,7 @@ final class WidgetSnapshotSkewTests: XCTestCase {
         let current = try decode("""
         {"providers": [
             {"id": "claude", "title": "Claude", "percent": 16,
+             "weekResetsAt": 1788094800,
              "layers": [
                 {"id": "session", "name": "Session", "percent": 4,
                  "resetsIn": "1h 34m"},
@@ -980,8 +981,10 @@ final class WidgetSnapshotSkewTests: XCTestCase {
         ]}
         """)
         XCTAssertEqual(
-            current.providers.first?.widgetResetLabels,
-            ["5h 1h34m", "Weekly 5d2h"]
+            current.providers.first?.widgetResetLabels(
+                in: try XCTUnwrap(TimeZone(secondsFromGMT: 0))
+            ),
+            ["5h: 1h34m", "1w: 5d2h, Sun 1pm"]
         )
 
         let older = try decode("""
@@ -991,7 +994,7 @@ final class WidgetSnapshotSkewTests: XCTestCase {
         """)
         XCTAssertEqual(
             older.providers.first?.widgetResetLabels,
-            ["5h —", "Weekly —"]
+            ["5h: —", "1w: —"]
         )
     }
 
@@ -1015,7 +1018,15 @@ final class WidgetSnapshotSkewTests: XCTestCase {
                     "pace_pct": 8, "resets_in": "1h 34m", "ring": true
                   }
                 }
-              }]
+              }],
+              "burndown": {
+                "claude": {
+                  "week": {
+                    "provider": "claude", "pool": "week",
+                    "window_end": 1788094800, "window_s": 604800
+                  }
+                }
+              }
             }
             """.utf8)
         )
@@ -1025,6 +1036,7 @@ final class WidgetSnapshotSkewTests: XCTestCase {
         XCTAssertEqual(provider.paceDeltaPct, 11)
         XCTAssertEqual(provider.sessionResetsIn, "1h 34m")
         XCTAssertEqual(provider.weekResetsIn, "5d 2h")
+        XCTAssertEqual(provider.weekResetsAt, 1788094800)
         XCTAssertEqual(
             provider.layers?.first { $0.id == "session" }?.resetsIn,
             "1h 34m"
@@ -1062,7 +1074,7 @@ final class WidgetSnapshotSkewTests: XCTestCase {
             HeadroomWidgetCache.save(usage).providers.first)
         XCTAssertEqual(
             provider.widgetResetLabels,
-            ["5h 1h34m", "Weekly 5d2h"]
+            ["5h: 1h34m", "1w: 5d2h"]
         )
     }
 

--- a/macos/Tests/ContractTests.swift
+++ b/macos/Tests/ContractTests.swift
@@ -141,6 +141,70 @@ final class ContractTests: XCTestCase {
         )
     }
 
+    /// Catches the overview falling back to one global burndown headline
+    /// instead of naming each provider's own pace, reset, and slack.
+    func testQuotaOverviewSummariesNameEachProvider() throws {
+        let json = """
+        {
+          "providers": [
+            {"id": "claude", "title": "Claude", "enabled": true,
+             "headline": "week", "pools": {
+               "week": {"title": "Weekly", "pct": 10, "window_s": 604800,
+                        "ring": true}
+             }},
+            {"id": "codex", "title": "Codex", "enabled": true,
+             "headline": "week", "pools": {
+               "week": {"title": "Weekly", "pct": 12, "window_s": 604800,
+                        "ring": true}
+             }}
+          ],
+          "burndown": {
+            "claude": {"week": {
+              "provider": "claude", "pool": "week", "status": "ok",
+              "window_end": 1788094800, "window_s": 604800,
+              "delta_pct": 11
+            }},
+            "codex": {"week": {
+              "provider": "codex", "pool": "week", "status": "ok",
+              "window_end": 1788141600, "window_s": 604800,
+              "delta_pct": 7
+            }}
+          },
+          "burndown_primary": {
+            "provider": "claude", "pool": "week",
+            "headline": "This global line must not be used"
+          }
+        }
+        """
+        let snapshot = try JSONDecoder().decode(
+            UsageSnapshot.self, from: Data(json.utf8))
+
+        XCTAssertEqual(
+            QuotaOverviewSummary.lines(
+                for: snapshot,
+                timeZone: try XCTUnwrap(TimeZone(secondsFromGMT: 0))
+            ),
+            [
+                "Claude: on pace. reset Sun 1pm, 11% to spare.",
+                "Codex: on pace. reset Mon 2am, 7% to spare.",
+            ]
+        )
+    }
+
+    /// A provider burning too quickly must not be described as on pace; the
+    /// signed distance also has to keep its "over" direction.
+    func testQuotaOverviewSummaryNamesOverPace() {
+        XCTAssertEqual(
+            HeadroomCopy.quotaOverviewSummary(
+                provider: "Claude",
+                overPace: true,
+                resetEpoch: nil,
+                deltaPct: -4
+            ),
+            "Claude: over pace. 4% over."
+        )
+    }
+
     func testEveryProviderMeterResolves() throws {
         let snapshot = try decodeDemo()
         for provider in snapshot.activeQuotaProviders {

--- a/macos/Tests/ContractTests.swift
+++ b/macos/Tests/ContractTests.swift
@@ -932,45 +932,54 @@ final class WidgetSnapshotSkewTests: XCTestCase {
         XCTAssertEqual(provider.percent, 0)
     }
 
-    /// The medium widget's pace slot is required. A cache without the new
-    /// field gets an explicit unknown reading rather than losing the label.
-    func testWidgetPaceSlackAlwaysHasAReading() throws {
+    /// The medium widget spends one line per provider on the complete reading,
+    /// leaving the rest of the tile to the graph. A cache without pace still
+    /// keeps that one-line shape and says which part is unknown.
+    func testMacMediumWidgetUsesOneProviderSummaryLine() throws {
         let current = try decode("""
         {"providers": [
-            {"id": "claude", "title": "Claude", "percent": 16,
-             "paceDeltaPct": 11}
+            {"id": "claude", "title": "Claude", "percent": 11,
+             "paceDeltaPct": 33}
         ]}
         """)
         XCTAssertEqual(
             current.providers.first?.widgetPaceSlackLabel,
-            "11% to spare"
+            "33% to spare",
+            "shared iPhone/watch presentation stays unchanged"
+        )
+        XCTAssertEqual(
+            current.providers.first?.macWidgetMediumSummaryLabel,
+            "Claude: 89% left, 33% spare"
         )
 
         let older = try decode("""
         {"providers": [
-            {"id": "claude", "title": "Claude", "percent": 16}
+            {"id": "claude", "title": "Claude", "percent": 11}
         ]}
         """)
         XCTAssertEqual(
-            older.providers.first?.widgetPaceSlackLabel,
-            "— to spare"
+            older.providers.first?.macWidgetMediumSummaryLabel,
+            "Claude: 89% left, — spare"
         )
 
         let over = try decode("""
         {"providers": [
-            {"id": "codex", "title": "Codex", "percent": 64,
+            {"id": "codex", "title": "Codex", "percent": 14,
              "paceDeltaPct": -4}
         ]}
         """)
-        XCTAssertEqual(over.providers.first?.widgetPaceSlackLabel, "4% over")
+        XCTAssertEqual(
+            over.providers.first?.macWidgetMediumSummaryLabel,
+            "Codex: 86% left, 4% over"
+        )
     }
 
-    /// The small widget reserves both reset rows even when it reads a cache
-    /// written before reset countdowns were added.
-    func testWidgetResetRowsAreAlwaysPresent() throws {
-        let current = try decode("""
+    /// The small widget only spends reset rows on readings useful for that
+    /// provider: Claude gets its five-hour clock and Codex gets neither.
+    func testMacSmallWidgetUsesProviderSpecificResetRows() throws {
+        let claude = try decode("""
         {"providers": [
-            {"id": "claude", "title": "Claude", "percent": 16,
+            {"id": "claude:work", "title": "Work", "percent": 16,
              "weekResetsAt": 1788094800,
              "layers": [
                 {"id": "session", "name": "Session", "percent": 4,
@@ -981,19 +990,40 @@ final class WidgetSnapshotSkewTests: XCTestCase {
         ]}
         """)
         XCTAssertEqual(
-            current.providers.first?.widgetResetLabels(
+            claude.providers.first?.widgetResetLabels(
                 in: try XCTUnwrap(TimeZone(secondsFromGMT: 0))
             ),
-            ["5h: 1h34m", "1w: 5d2h, Sun 1pm"]
+            ["5h: 1h34m", "1w: 5d2h, Sun 1pm"],
+            "shared iPhone/watch presentation stays unchanged"
+        )
+        XCTAssertEqual(
+            claude.providers.first?.macWidgetResetLabels(
+                in: try XCTUnwrap(TimeZone(secondsFromGMT: 0))
+            ),
+            ["5h: 1h34m"]
         )
 
-        let older = try decode("""
+        let codex = try decode("""
         {"providers": [
-            {"id": "codex", "title": "Codex", "percent": 9}
+            {"id": "codex:team", "title": "Team", "percent": 9,
+             "sessionResetsIn": "2h 54m", "weekResetsIn": "4d 13h"}
         ]}
         """)
         XCTAssertEqual(
-            older.providers.first?.widgetResetLabels,
+            codex.providers.first?.widgetResetLabels,
+            ["5h: 2h54m", "1w: 4d13h"],
+            "shared iPhone/watch presentation stays unchanged"
+        )
+        XCTAssertEqual(codex.providers.first?.macWidgetResetLabels, [])
+
+        // Providers not named by this density rule keep their existing rows.
+        let other = try decode("""
+        {"providers": [
+            {"id": "cursor", "title": "Cursor", "percent": 9}
+        ]}
+        """)
+        XCTAssertEqual(
+            other.providers.first?.macWidgetResetLabels,
             ["5h: —", "1w: —"]
         )
     }
@@ -1114,6 +1144,10 @@ final class WidgetSnapshotSkewTests: XCTestCase {
         XCTAssertEqual(provider.percent, 80)
         XCTAssertNil(provider.paceDeltaPct)
         XCTAssertEqual(provider.widgetPaceSlackLabel, "— to spare")
+        XCTAssertEqual(
+            provider.macWidgetMediumSummaryLabel,
+            "Claude: 20% left, — spare"
+        )
     }
 
     func testAnAbsentBurndownCurveIsEmptyNotAFailure() throws {

--- a/macos/Tests/ContractTests.swift
+++ b/macos/Tests/ContractTests.swift
@@ -932,6 +932,178 @@ final class WidgetSnapshotSkewTests: XCTestCase {
         XCTAssertEqual(provider.percent, 0)
     }
 
+    /// The medium widget's pace slot is required. A cache without the new
+    /// field gets an explicit unknown reading rather than losing the label.
+    func testWidgetPaceSlackAlwaysHasAReading() throws {
+        let current = try decode("""
+        {"providers": [
+            {"id": "claude", "title": "Claude", "percent": 16,
+             "paceDeltaPct": 11}
+        ]}
+        """)
+        XCTAssertEqual(
+            current.providers.first?.widgetPaceSlackLabel,
+            "11% to spare"
+        )
+
+        let older = try decode("""
+        {"providers": [
+            {"id": "claude", "title": "Claude", "percent": 16}
+        ]}
+        """)
+        XCTAssertEqual(
+            older.providers.first?.widgetPaceSlackLabel,
+            "— to spare"
+        )
+
+        let over = try decode("""
+        {"providers": [
+            {"id": "codex", "title": "Codex", "percent": 64,
+             "paceDeltaPct": -4}
+        ]}
+        """)
+        XCTAssertEqual(over.providers.first?.widgetPaceSlackLabel, "4% over")
+    }
+
+    /// The small widget reserves both reset rows even when it reads a cache
+    /// written before reset countdowns were added.
+    func testWidgetResetRowsAreAlwaysPresent() throws {
+        let current = try decode("""
+        {"providers": [
+            {"id": "claude", "title": "Claude", "percent": 16,
+             "layers": [
+                {"id": "session", "name": "Session", "percent": 4,
+                 "resetsIn": "1h 34m"},
+                {"id": "week", "name": "Weekly", "percent": 16,
+                 "resetsIn": "5d 2h"}
+             ]}
+        ]}
+        """)
+        XCTAssertEqual(
+            current.providers.first?.widgetResetLabels,
+            ["5h 1h34m", "Weekly 5d2h"]
+        )
+
+        let older = try decode("""
+        {"providers": [
+            {"id": "codex", "title": "Codex", "percent": 9}
+        ]}
+        """)
+        XCTAssertEqual(
+            older.providers.first?.widgetResetLabels,
+            ["5h —", "Weekly —"]
+        )
+    }
+
+    /// The app has to carry the live pool values into the widget cache. The
+    /// presentation fallbacks above must not mask a writer that drops them.
+    func testWidgetCacheCarriesPaceAndResetReadings() throws {
+        let usage = try JSONDecoder().decode(
+            UsageSnapshot.self,
+            from: Data("""
+            {
+              "focus": ["claude"],
+              "providers": [{
+                "id": "claude", "title": "Claude", "enabled": true,
+                "pools": {
+                  "week": {
+                    "title": "Weekly", "rank": 0, "pct": 16,
+                    "pace_pct": 27, "resets_in": "5d 2h", "ring": true
+                  },
+                  "session": {
+                    "title": "Session", "rank": 1, "pct": 4,
+                    "pace_pct": 8, "resets_in": "1h 34m", "ring": true
+                  }
+                }
+              }]
+            }
+            """.utf8)
+        )
+
+        let cached = HeadroomWidgetCache.save(usage)
+        let provider = try XCTUnwrap(cached.providers.first)
+        XCTAssertEqual(provider.paceDeltaPct, 11)
+        XCTAssertEqual(provider.sessionResetsIn, "1h 34m")
+        XCTAssertEqual(provider.weekResetsIn, "5d 2h")
+        XCTAssertEqual(
+            provider.layers?.first { $0.id == "session" }?.resetsIn,
+            "1h 34m"
+        )
+        XCTAssertEqual(
+            provider.layers?.first { $0.id == "week" }?.resetsIn,
+            "5d 2h"
+        )
+    }
+
+    func testWidgetCacheKeepsResetWithoutARingReading() throws {
+        let usage = try JSONDecoder().decode(
+            UsageSnapshot.self,
+            from: Data("""
+            {
+              "focus": ["claude"],
+              "providers": [{
+                "id": "claude", "title": "Claude", "enabled": true,
+                "pools": {
+                  "week": {
+                    "title": "Weekly", "rank": 0, "pct": 16,
+                    "resets_in": "5d 2h", "ring": true
+                  },
+                  "session": {
+                    "title": "Session", "rank": 1, "pct": null,
+                    "resets_in": "1h 34m", "ring": true
+                  }
+                }
+              }]
+            }
+            """.utf8)
+        )
+
+        let provider = try XCTUnwrap(
+            HeadroomWidgetCache.save(usage).providers.first)
+        XCTAssertEqual(
+            provider.widgetResetLabels,
+            ["5h 1h34m", "Weekly 5d2h"]
+        )
+    }
+
+    func testWidgetPaceNeverBorrowsFromAnotherPool() throws {
+        let usage = try JSONDecoder().decode(
+            UsageSnapshot.self,
+            from: Data("""
+            {
+              "focus": ["claude"],
+              "providers": [{
+                "id": "claude", "title": "Claude", "enabled": true,
+                "pools": {
+                  "week": {
+                    "title": "Weekly", "rank": 0, "pct": 20,
+                    "ring": true
+                  },
+                  "session": {
+                    "title": "Session", "rank": 1, "pct": 80,
+                    "ring": true
+                  }
+                }
+              }],
+              "burndown": {
+                "claude": {
+                  "week": {
+                    "provider": "claude", "pool": "week",
+                    "window_s": 604800, "delta_pct": 10
+                  }
+                }
+              }
+            }
+            """.utf8)
+        )
+
+        let provider = try XCTUnwrap(
+            HeadroomWidgetCache.save(usage).providers.first)
+        XCTAssertEqual(provider.percent, 80)
+        XCTAssertNil(provider.paceDeltaPct)
+        XCTAssertEqual(provider.widgetPaceSlackLabel, "— to spare")
+    }
+
     func testAnAbsentBurndownCurveIsEmptyNotAFailure() throws {
         let snapshot = try decode("""
         {"updatedAt": 0, "providers": [
@@ -1064,8 +1236,16 @@ final class WidgetSnapshotSkewTests: XCTestCase {
                     title: "Claude",
                     name: "Claude · Work",
                     percent: 42,
+                    paceDeltaPct: 9,
+                    sessionResetsIn: "2h 3m",
+                    weekResetsIn: "3d 4h",
                     accent: "#D97757",
-                    layers: [.init(id: "week", name: "Week", percent: 42)],
+                    layers: [
+                        .init(
+                            id: "week", name: "Week", percent: 42,
+                            resetsIn: "3d 4h"
+                        ),
+                    ],
                     burndown: .init(
                         actual: [[1, 100], [2, 80]],
                         projected: [[2, 80], [3, 60]])
@@ -1079,7 +1259,11 @@ final class WidgetSnapshotSkewTests: XCTestCase {
         XCTAssertEqual(read.attentionSummary, "one build failed")
         XCTAssertEqual(read.providers.first?.name, "Claude · Work")
         XCTAssertEqual(read.providers.first?.percent, 42)
+        XCTAssertEqual(read.providers.first?.paceDeltaPct, 9)
+        XCTAssertEqual(read.providers.first?.sessionResetsIn, "2h 3m")
+        XCTAssertEqual(read.providers.first?.weekResetsIn, "3d 4h")
         XCTAssertEqual(read.providers.first?.layers?.first?.name, "Week")
+        XCTAssertEqual(read.providers.first?.layers?.first?.resetsIn, "3d 4h")
         XCTAssertEqual(read.providers.first?.burndown?.actual.count, 2)
     }
 }

--- a/macos/Tests/ContractTests.swift
+++ b/macos/Tests/ContractTests.swift
@@ -205,6 +205,27 @@ final class ContractTests: XCTestCase {
         )
     }
 
+    /// Keeps the decoded burndown status wired through the overview instead
+    /// of testing only the copy formatter's Boolean input.
+    func testQuotaOverviewSummariesMapDecodedOverPaceStatus() throws {
+        let json = """
+        {
+          "providers": [{"id": "claude", "title": "Claude", "enabled": true}],
+          "burndown": {"claude": {"week": {
+            "provider": "claude", "pool": "week", "status": "ahead",
+            "window_s": 604800, "delta_pct": -4
+          }}}
+        }
+        """
+        let snapshot = try JSONDecoder().decode(
+            UsageSnapshot.self, from: Data(json.utf8))
+
+        XCTAssertEqual(
+            QuotaOverviewSummary.lines(for: snapshot),
+            ["Claude: over pace. 4% over."]
+        )
+    }
+
     func testEveryProviderMeterResolves() throws {
         let snapshot = try decodeDemo()
         for provider in snapshot.activeQuotaProviders {

--- a/macos/Tests/ContractTests.swift
+++ b/macos/Tests/ContractTests.swift
@@ -141,21 +141,21 @@ final class ContractTests: XCTestCase {
         )
     }
 
-    /// Catches the overview falling back to one global burndown headline
-    /// instead of naming each provider's own pace, reset, and slack.
-    func testQuotaOverviewSummariesNameEachProvider() throws {
+    /// Catches the overview falling back to detached provider sentences
+    /// instead of the two captions that belong under each provider's ring.
+    func testQuotaOverviewColumnsCarryEachProvidersResetAndPace() throws {
         let json = """
         {
           "providers": [
             {"id": "claude", "title": "Claude", "enabled": true,
              "headline": "week", "pools": {
                "week": {"title": "Weekly", "pct": 10, "window_s": 604800,
-                        "ring": true}
+                        "resets_in": "5d 1h", "ring": true}
              }},
             {"id": "codex", "title": "Codex", "enabled": true,
              "headline": "week", "pools": {
                "week": {"title": "Weekly", "pct": 12, "window_s": 604800,
-                        "ring": true}
+                        "resets_in": "5d 10h", "ring": true}
              }}
           ],
           "burndown": {
@@ -179,14 +179,16 @@ final class ContractTests: XCTestCase {
         let snapshot = try JSONDecoder().decode(
             UsageSnapshot.self, from: Data(json.utf8))
 
+        let columns = QuotaOverviewSummary.columns(
+            for: snapshot,
+            timeZone: try XCTUnwrap(TimeZone(secondsFromGMT: 0))
+        )
+        XCTAssertEqual(columns.map(\.providerID), ["claude", "codex"])
         XCTAssertEqual(
-            QuotaOverviewSummary.lines(
-                for: snapshot,
-                timeZone: try XCTUnwrap(TimeZone(secondsFromGMT: 0))
-            ),
+            columns.map { [$0.resetLine ?? "", $0.paceLine] },
             [
-                "Claude: on pace. reset Sun 1pm, 11% to spare.",
-                "Codex: on pace. reset Mon 2am, 7% to spare.",
+                ["Reset: 5d1h, Sun 1pm.", "11% to Spare"],
+                ["Reset: 5d10h, Mon 2am.", "7% to Spare"],
             ]
         )
     }
@@ -195,13 +197,11 @@ final class ContractTests: XCTestCase {
     /// signed distance also has to keep its "over" direction.
     func testQuotaOverviewSummaryNamesOverPace() {
         XCTAssertEqual(
-            HeadroomCopy.quotaOverviewSummary(
-                provider: "Claude",
+            HeadroomCopy.quotaOverviewSlack(
                 overPace: true,
-                resetEpoch: nil,
                 deltaPct: -4
             ),
-            "Claude: over pace. 4% over."
+            "4% Over"
         )
     }
 
@@ -221,8 +221,8 @@ final class ContractTests: XCTestCase {
             UsageSnapshot.self, from: Data(json.utf8))
 
         XCTAssertEqual(
-            QuotaOverviewSummary.lines(for: snapshot),
-            ["Claude: over pace. 4% over."]
+            QuotaOverviewSummary.columns(for: snapshot).first?.paceLine,
+            "4% Over"
         )
     }
 

--- a/macos/Tests/ContractTests.swift
+++ b/macos/Tests/ContractTests.swift
@@ -794,6 +794,21 @@ final class WidgetSnapshotSkewTests: XCTestCase {
             HeadroomWidgetSnapshot.self, from: Data(json.utf8))
     }
 
+    func testWidgetKindsStayDistinctAndStable() {
+        // WidgetKit cannot migrate an already-placed StaticConfiguration to
+        // AppIntentConfiguration. Reusing this identity strands the old tile
+        // on its last snapshot; the configurable widget must be a new kind.
+        XCTAssertEqual(HeadroomWidgetIdentity.legacyKind, "HeadroomWidget")
+        XCTAssertEqual(
+            HeadroomWidgetIdentity.configurableKind,
+            "HeadroomWidget.Configurable"
+        )
+        XCTAssertNotEqual(
+            HeadroomWidgetIdentity.configurableKind,
+            HeadroomWidgetIdentity.legacyKind
+        )
+    }
+
     func testAnEmptyObjectStillDecodes() throws {
         // The floor: whatever a future build adds, the envelope survives.
         let snapshot = try decode("{}")

--- a/macos/Tests/ContractTests.swift
+++ b/macos/Tests/ContractTests.swift
@@ -794,6 +794,67 @@ final class WidgetSnapshotSkewTests: XCTestCase {
             HeadroomWidgetSnapshot.self, from: Data(json.utf8))
     }
 
+    func testStaticAndEditableWidgetsHaveStableDistinctKinds() {
+        // WidgetKit persists both the kind and configuration system for a
+        // placed tile. The original static definition has to keep the kind
+        // shipped before provider selection, while the editable definition
+        // needs a different identity so it cannot strand those tiles.
+        XCTAssertEqual(HeadroomWidgetIdentity.legacyKind, "HeadroomWidget")
+        XCTAssertEqual(
+            HeadroomWidgetIdentity.editableKind,
+            "HeadroomWidget.Configurable"
+        )
+        XCTAssertNotEqual(
+            HeadroomWidgetIdentity.legacyKind,
+            HeadroomWidgetIdentity.editableKind
+        )
+    }
+
+    func testWidgetBundleKeepsBothConfigurationSystems() throws {
+        // The strings above only protect persisted identity. This protects the
+        // wiring that uses it: dropping the compatibility widget, or putting
+        // the old kind on the App Intent definition again, recreates the
+        // indefinitely frozen tiles this migration exists to recover.
+        let testFile = URL(fileURLWithPath: #filePath)
+        let sourceURL = testFile
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // macos
+            .deletingLastPathComponent()  // repo root
+            .appendingPathComponent("widget/HeadroomWidget.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        func section(from start: String, to end: String?) throws -> Substring {
+            let startRange = try XCTUnwrap(source.range(of: start))
+            let suffix = source[startRange.lowerBound...]
+            guard let end else { return suffix }
+            let endRange = try XCTUnwrap(suffix.range(of: end))
+            return suffix[..<endRange.lowerBound]
+        }
+        func compact(_ value: Substring) -> String {
+            value.filter { !$0.isWhitespace }
+        }
+
+        let bundle = try section(
+            from: "struct HeadroomWidgetBundle", to: "private enum HeadroomWidgetGallery")
+        XCTAssertTrue(bundle.contains("HeadroomLegacyStatusWidget()"))
+        XCTAssertTrue(bundle.contains("HeadroomStatusWidget()"))
+
+        let legacy = compact(try section(
+            from: "struct HeadroomLegacyStatusWidget", to: "struct HeadroomStatusWidget"))
+        XCTAssertTrue(legacy.contains(
+            "StaticConfiguration(kind:HeadroomWidgetIdentity.legacyKind,"
+                + "provider:HeadroomLegacyWidgetProvider()"
+        ))
+
+        let editable = compact(try section(
+            from: "struct HeadroomStatusWidget", to: nil))
+        XCTAssertTrue(editable.contains(
+            "AppIntentConfiguration(kind:HeadroomWidgetIdentity.editableKind,"
+                + "intent:HeadroomWidgetConfiguration.self,"
+                + "provider:HeadroomWidgetProvider()"
+        ))
+    }
+
     func testAnEmptyObjectStillDecodes() throws {
         // The floor: whatever a future build adds, the envelope survives.
         let snapshot = try decode("{}")
@@ -934,7 +995,7 @@ final class WidgetSnapshotSkewTests: XCTestCase {
         ]}
         """)
         XCTAssertEqual(snapshot.showing("codex").providers.map(\.id), ["codex"])
-        // The default, and every widget placed before the picker existed.
+        // The editable widget's explicit All providers/absent-parameter path.
         XCTAssertEqual(
             snapshot.showing(nil).providers.map(\.id), ["claude", "codex"])
     }

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -145,6 +145,7 @@ targets:
     sources:
       - path: ../widget/HeadroomWidget.swift
       - path: ../widget/HeadroomWidgetIntent.swift
+      - path: ../Shared/WidgetIdentity.swift
       - path: ../Shared/WidgetSnapshot.swift
       - path: ../Shared/LossyDecode.swift
       - path: ../Shared/HeadroomRings.swift
@@ -177,6 +178,7 @@ targets:
     sources:
       - path: ../widget/HeadroomWidget.swift
       - path: ../widget/HeadroomWidgetIntent.swift
+      - path: ../Shared/WidgetIdentity.swift
       - path: ../Shared/WidgetSnapshot.swift
       - path: ../Shared/LossyDecode.swift
       - path: ../Shared/HeadroomRings.swift

--- a/widget/HeadroomWidget.swift
+++ b/widget/HeadroomWidget.swift
@@ -151,18 +151,33 @@ struct HeadroomWidgetView: View {
         VStack(alignment: .leading, spacing: 0) {
             if providers.count == 1, let solo = providers.first {
                 HeadroomRings(layers: solo.ringLayers, tint: solo.tint)
-                    .frame(width: 62, height: 62)
-                Spacer(minLength: 8)
+                    .frame(
+                        width: entry.snapshot.isStale ? 46 : 62,
+                        height: entry.snapshot.isStale ? 46 : 62
+                    )
+                Spacer(minLength: entry.snapshot.isStale ? 4 : 8)
                 Text(solo.title)
                     .font(.caption.weight(.semibold))
                     .lineLimit(1)
                 Text(HeadroomCopy.percentUsed(solo.percent))
                     .font(.caption2.monospacedDigit())
                     .foregroundStyle(.secondary)
+                ForEach(solo.widgetResetLabels, id: \.self) { label in
+                    Text(label)
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
             } else if providers.isEmpty {
                 emptyLine
             } else {
-                ringRow(diameter: providers.count > 2 ? 38 : 50)
+                ringRow(
+                    diameter: providers.count > 2
+                        ? (entry.snapshot.isStale ? 32 : 38)
+                        : (entry.snapshot.isStale ? 38 : 50),
+                    showsResets: true,
+                    showsPace: false
+                )
             }
             staleNote
         }
@@ -178,8 +193,15 @@ struct HeadroomWidgetView: View {
             VStack(alignment: .leading, spacing: 0) { emptyLine }
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         } else if charted.isEmpty {
-            VStack(alignment: .leading, spacing: 8) {
-                ringRow(diameter: 54)
+            VStack(
+                alignment: .leading,
+                spacing: entry.snapshot.isStale ? 4 : 8
+            ) {
+                ringRow(
+                    diameter: entry.snapshot.isStale ? 40 : 54,
+                    showsResets: false,
+                    showsPace: true
+                )
                 Text(HeadroomCopy.noHistoryYet)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
@@ -195,13 +217,21 @@ struct HeadroomWidgetView: View {
         }
     }
 
-    /// One cell per source: its rings, its name, its reading. Used by the small
-    /// family whenever there is more than one source, and by both families when
-    /// there is no history to chart yet.
-    private func ringRow(diameter: CGFloat) -> some View {
-        HStack(alignment: .top, spacing: 12) {
+    /// One cell per source: its rings, its name, and its readings. The small
+    /// family reserves both reset rows; the medium fallback reserves pace,
+    /// matching the chart legend even before history arrives.
+    private func ringRow(
+        diameter: CGFloat,
+        showsResets: Bool,
+        showsPace: Bool
+    ) -> some View {
+        HStack(alignment: .top, spacing: providers.count > 2 ? 4 : 8) {
             ForEach(providers) { provider in
-                VStack(spacing: 5) {
+                VStack(
+                    spacing: entry.snapshot.isStale
+                        ? 2
+                        : (providers.count > 2 ? 3 : 5)
+                ) {
                     HeadroomRings(
                         layers: provider.ringLayers, tint: provider.tint
                     )
@@ -209,14 +239,34 @@ struct HeadroomWidgetView: View {
                     Text(provider.title)
                         .font(.caption2)
                         .lineLimit(1)
+                        .minimumScaleFactor(0.5)
                     Text(HeadroomCopy.percentUsed(provider.percent))
                         .font(.caption2.monospacedDigit())
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                         .minimumScaleFactor(0.6)
+                    if showsPace {
+                        Text(provider.widgetPaceSlackLabel)
+                            .font(.caption2.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.6)
+                    }
+                    if showsResets {
+                        ForEach(provider.widgetResetLabels, id: \.self) { label in
+                            Text(label)
+                                .font(.caption2.monospacedDigit())
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.5)
+                        }
+                    }
                 }
+                .frame(
+                    maxWidth: providers.count > 1 ? .infinity : nil,
+                    alignment: .top
+                )
             }
-            Spacer(minLength: 0)
         }
     }
 
@@ -229,20 +279,27 @@ struct HeadroomWidgetView: View {
     /// A source with no line still gets its row: it is one of your sources, and
     /// a widget that quietly drops it reads as a widget that lost it.
     private var legend: some View {
-        HStack(spacing: 10) {
+        HStack(alignment: .top, spacing: 8) {
             ForEach(providers) { provider in
-                HStack(spacing: 4) {
-                    Capsule()
-                        .fill(provider.burndownTint)
-                        .frame(width: 10, height: 2.5)
-                    Text(provider.title)
-                        .font(.caption2)
-                        .lineLimit(1)
+                VStack(alignment: .leading, spacing: 1) {
+                    HStack(spacing: 4) {
+                        Capsule()
+                            .fill(provider.burndownTint)
+                            .frame(width: 10, height: 2.5)
+                        Text(provider.title)
+                            .font(.caption2)
+                            .lineLimit(1)
+                    }
                     Text(HeadroomCopy.percentLeft(100 - provider.percent))
                         .font(.caption2.monospacedDigit())
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
+                    Text(provider.widgetPaceSlackLabel)
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .layoutPriority(1)
             }
             Spacer(minLength: 0)

--- a/widget/HeadroomWidget.swift
+++ b/widget/HeadroomWidget.swift
@@ -69,6 +69,43 @@ struct HeadroomWidgetProvider: AppIntentTimelineProvider {
     }
 }
 
+/// Keeps every tile placed before provider selection existed alive.
+///
+/// Those tiles were serialized as a `StaticConfiguration` with the kind
+/// `HeadroomWidget`. WidgetKit does not migrate an existing tile when the same
+/// kind changes configuration systems; it leaves the tile on its last render
+/// instead. Keeping that exact static definition lets WidgetKit resume asking
+/// for timelines, while configurable tiles use a new identity below.
+struct HeadroomLegacyWidgetProvider: TimelineProvider {
+    func placeholder(in context: Context) -> HeadroomWidgetEntry {
+        HeadroomWidgetEntry(date: .now, snapshot: .placeholder)
+    }
+
+    func getSnapshot(
+        in context: Context,
+        completion: @escaping (HeadroomWidgetEntry) -> Void
+    ) {
+        let snapshot = context.isPreview ? .placeholder : load()
+        completion(HeadroomWidgetEntry(date: .now, snapshot: snapshot))
+    }
+
+    func getTimeline(
+        in context: Context,
+        completion: @escaping (Timeline<HeadroomWidgetEntry>) -> Void
+    ) {
+        completion(
+            Timeline(
+                entries: [HeadroomWidgetEntry(date: .now, snapshot: load())],
+                policy: .after(Date(timeIntervalSinceNow: 15 * 60))
+            )
+        )
+    }
+
+    private func load() -> HeadroomWidgetSnapshot {
+        HeadroomWidgetSnapshot.cached() ?? .awaitingFirstSync
+    }
+}
+
 /// No product name, no status dot. A widget the user chose to place already
 /// says which app it belongs to, and the chart says the rest — both of them
 /// were spending the small size's only real currency, which is height.
@@ -350,35 +387,52 @@ private struct CombinedBurndownChart: View {
 @main
 struct HeadroomWidgetBundle: WidgetBundle {
     var body: some Widget {
+        HeadroomLegacyStatusWidget()
         HeadroomStatusWidget()
     }
 }
 
-struct HeadroomStatusWidget: Widget {
+private enum HeadroomWidgetGallery {
     /// Same extension, two homes. On the Mac the numbers never left the machine
     /// the widget is sitting on, so "from your Mac" would read strangely there.
-    private static var gallerySubtitle: String {
+    static var subtitle: String {
         #if os(macOS)
         return "Coding quota and attention status at a glance."
         #else
         return "Coding quota and attention status from your Mac."
         #endif
     }
+}
 
+/// The original, all-provider widget. Its definition is retained because its
+/// kind and configuration type are part of every tile WidgetKit already saved.
+struct HeadroomLegacyStatusWidget: Widget {
     var body: some WidgetConfiguration {
-        // The kind is the identity of every already-placed tile, so it stays
-        // what it has always been. Widgets placed before this was
-        // configurable get the default configuration, which is the behaviour
-        // they already had: every provider the host sent.
+        StaticConfiguration(
+            kind: HeadroomWidgetIdentity.legacyKind,
+            provider: HeadroomLegacyWidgetProvider()
+        ) { entry in
+            HeadroomWidgetView(entry: entry)
+        }
+        .configurationDisplayName("Headroom — All providers")
+        .description(HeadroomWidgetGallery.subtitle)
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+/// New placements can select one provider without changing the serialized
+/// definition of the original widget.
+struct HeadroomStatusWidget: Widget {
+    var body: some WidgetConfiguration {
         AppIntentConfiguration(
-            kind: "HeadroomWidget",
+            kind: HeadroomWidgetIdentity.configurableKind,
             intent: HeadroomWidgetConfiguration.self,
             provider: HeadroomWidgetProvider()
         ) { entry in
             HeadroomWidgetView(entry: entry)
         }
-        .configurationDisplayName(HeadroomCopy.product)
-        .description(Self.gallerySubtitle)
+        .configurationDisplayName("Headroom — Provider")
+        .description(HeadroomWidgetGallery.subtitle)
         .supportedFamilies([.systemSmall, .systemMedium])
     }
 }

--- a/widget/HeadroomWidget.swift
+++ b/widget/HeadroomWidget.swift
@@ -162,7 +162,7 @@ struct HeadroomWidgetView: View {
                 Text(HeadroomCopy.percentUsed(solo.percent))
                     .font(.caption2.monospacedDigit())
                     .foregroundStyle(.secondary)
-                ForEach(solo.widgetResetLabels, id: \.self) { label in
+                ForEach(smallResetLabels(for: solo), id: \.self) { label in
                     Text(label)
                         .font(.caption2.monospacedDigit())
                         .foregroundStyle(.secondary)
@@ -175,8 +175,7 @@ struct HeadroomWidgetView: View {
                     diameter: providers.count > 2
                         ? (entry.snapshot.isStale ? 32 : 38)
                         : (entry.snapshot.isStale ? 38 : 50),
-                    showsResets: true,
-                    showsPace: false
+                    showsMediumSummary: false
                 )
             }
             staleNote
@@ -199,8 +198,7 @@ struct HeadroomWidgetView: View {
             ) {
                 ringRow(
                     diameter: entry.snapshot.isStale ? 40 : 54,
-                    showsResets: false,
-                    showsPace: true
+                    showsMediumSummary: true
                 )
                 Text(HeadroomCopy.noHistoryYet)
                     .font(.caption2)
@@ -217,13 +215,12 @@ struct HeadroomWidgetView: View {
         }
     }
 
-    /// One cell per source: its rings, its name, and its readings. The small
-    /// family reserves both reset rows; the medium fallback reserves pace,
-    /// matching the chart legend even before history arrives.
+    /// One cell per source. Small widgets name the source and keep only its
+    /// useful reset clocks; medium fallbacks put the entire reading on one
+    /// line, matching the chart legend even before history arrives.
     private func ringRow(
         diameter: CGFloat,
-        showsResets: Bool,
-        showsPace: Bool
+        showsMediumSummary: Bool
     ) -> some View {
         HStack(alignment: .top, spacing: providers.count > 2 ? 4 : 8) {
             ForEach(providers) { provider in
@@ -236,6 +233,34 @@ struct HeadroomWidgetView: View {
                         layers: provider.ringLayers, tint: provider.tint
                     )
                     .frame(width: diameter, height: diameter)
+                    #if os(macOS)
+                    if showsMediumSummary {
+                        Text(provider.macWidgetMediumSummaryLabel)
+                            .font(.caption2.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.5)
+                    } else {
+                        Text(provider.title)
+                            .font(.caption2)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.5)
+                        Text(HeadroomCopy.percentUsed(provider.percent))
+                            .font(.caption2.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.6)
+                        ForEach(
+                            provider.macWidgetResetLabels, id: \.self
+                        ) { label in
+                            Text(label)
+                                .font(.caption2.monospacedDigit())
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.5)
+                        }
+                    }
+                    #else
                     Text(provider.title)
                         .font(.caption2)
                         .lineLimit(1)
@@ -245,14 +270,13 @@ struct HeadroomWidgetView: View {
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                         .minimumScaleFactor(0.6)
-                    if showsPace {
+                    if showsMediumSummary {
                         Text(provider.widgetPaceSlackLabel)
                             .font(.caption2.monospacedDigit())
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                             .minimumScaleFactor(0.6)
-                    }
-                    if showsResets {
+                    } else {
                         ForEach(provider.widgetResetLabels, id: \.self) { label in
                             Text(label)
                                 .font(.caption2.monospacedDigit())
@@ -261,6 +285,7 @@ struct HeadroomWidgetView: View {
                                 .minimumScaleFactor(0.5)
                         }
                     }
+                    #endif
                 }
                 .frame(
                     maxWidth: providers.count > 1 ? .infinity : nil,
@@ -281,6 +306,19 @@ struct HeadroomWidgetView: View {
     private var legend: some View {
         HStack(alignment: .top, spacing: 8) {
             ForEach(providers) { provider in
+                Group {
+                #if os(macOS)
+                HStack(spacing: 4) {
+                    Capsule()
+                        .fill(provider.burndownTint)
+                        .frame(width: 10, height: 2.5)
+                    Text(provider.macWidgetMediumSummaryLabel)
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.5)
+                }
+                #else
                 VStack(alignment: .leading, spacing: 1) {
                     HStack(spacing: 4) {
                         Capsule()
@@ -299,6 +337,8 @@ struct HeadroomWidgetView: View {
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }
+                #endif
+                }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .layoutPriority(1)
             }
@@ -310,6 +350,16 @@ struct HeadroomWidgetView: View {
             }
         }
         .minimumScaleFactor(0.75)
+    }
+
+    private func smallResetLabels(
+        for provider: HeadroomWidgetSnapshot.Provider
+    ) -> [String] {
+        #if os(macOS)
+        provider.macWidgetResetLabels
+        #else
+        provider.widgetResetLabels
+        #endif
     }
 
     private var emptyLine: some View {

--- a/widget/HeadroomWidget.swift
+++ b/widget/HeadroomWidget.swift
@@ -69,6 +69,43 @@ struct HeadroomWidgetProvider: AppIntentTimelineProvider {
     }
 }
 
+/// Keeps every tile placed before provider selection existed alive.
+///
+/// Those tiles were serialized as a `StaticConfiguration` with the kind
+/// `HeadroomWidget`. WidgetKit does not migrate an existing tile when the same
+/// kind changes configuration systems; it leaves the tile on its last render
+/// instead. Keeping that exact static definition lets WidgetKit resume asking
+/// for timelines, while editable tiles use a new identity below.
+struct HeadroomLegacyWidgetProvider: TimelineProvider {
+    func placeholder(in context: Context) -> HeadroomWidgetEntry {
+        HeadroomWidgetEntry(date: .now, snapshot: .placeholder)
+    }
+
+    func getSnapshot(
+        in context: Context,
+        completion: @escaping (HeadroomWidgetEntry) -> Void
+    ) {
+        let snapshot = context.isPreview ? .placeholder : load()
+        completion(HeadroomWidgetEntry(date: .now, snapshot: snapshot))
+    }
+
+    func getTimeline(
+        in context: Context,
+        completion: @escaping (Timeline<HeadroomWidgetEntry>) -> Void
+    ) {
+        completion(
+            Timeline(
+                entries: [HeadroomWidgetEntry(date: .now, snapshot: load())],
+                policy: .after(Date(timeIntervalSinceNow: 15 * 60))
+            )
+        )
+    }
+
+    private func load() -> HeadroomWidgetSnapshot {
+        HeadroomWidgetSnapshot.cached() ?? .awaitingFirstSync
+    }
+}
+
 /// No product name, no status dot. A widget the user chose to place already
 /// says which app it belongs to, and the chart says the rest — both of them
 /// were spending the small size's only real currency, which is height.
@@ -350,35 +387,52 @@ private struct CombinedBurndownChart: View {
 @main
 struct HeadroomWidgetBundle: WidgetBundle {
     var body: some Widget {
+        HeadroomLegacyStatusWidget()
         HeadroomStatusWidget()
     }
 }
 
-struct HeadroomStatusWidget: Widget {
+private enum HeadroomWidgetGallery {
     /// Same extension, two homes. On the Mac the numbers never left the machine
     /// the widget is sitting on, so "from your Mac" would read strangely there.
-    private static var gallerySubtitle: String {
+    static var subtitle: String {
         #if os(macOS)
         return "Coding quota and attention status at a glance."
         #else
         return "Coding quota and attention status from your Mac."
         #endif
     }
+}
 
+/// The original all-provider widget. Its definition stays because its kind
+/// and configuration type are part of every tile WidgetKit already saved.
+struct HeadroomLegacyStatusWidget: Widget {
     var body: some WidgetConfiguration {
-        // The kind is the identity of every already-placed tile, so it stays
-        // what it has always been. Widgets placed before this was
-        // configurable get the default configuration, which is the behaviour
-        // they already had: every provider the host sent.
+        StaticConfiguration(
+            kind: HeadroomWidgetIdentity.legacyKind,
+            provider: HeadroomLegacyWidgetProvider()
+        ) { entry in
+            HeadroomWidgetView(entry: entry)
+        }
+        .configurationDisplayName("Headroom — All providers")
+        .description(HeadroomWidgetGallery.subtitle)
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+/// New placements can select one provider without changing the serialized
+/// definition of the original widget.
+struct HeadroomStatusWidget: Widget {
+    var body: some WidgetConfiguration {
         AppIntentConfiguration(
-            kind: "HeadroomWidget",
+            kind: HeadroomWidgetIdentity.editableKind,
             intent: HeadroomWidgetConfiguration.self,
             provider: HeadroomWidgetProvider()
         ) { entry in
             HeadroomWidgetView(entry: entry)
         }
-        .configurationDisplayName(HeadroomCopy.product)
-        .description(Self.gallerySubtitle)
+        .configurationDisplayName("Headroom — Provider")
+        .description(HeadroomWidgetGallery.subtitle)
         .supportedFamilies([.systemSmall, .systemMedium])
     }
 }

--- a/widget/HeadroomWidgetIntent.swift
+++ b/widget/HeadroomWidgetIntent.swift
@@ -111,11 +111,10 @@ struct HeadroomWidgetConfiguration: WidgetConfigurationIntent {
 
     /// Nil when the tile draws everything it is given.
     ///
-    /// Two paths reach that: the explicit "All providers" choice, and a tile
-    /// placed before this configuration existed, which carries no parameter at
-    /// all. Both drew every provider before and both keep drawing every
-    /// provider — the new single-provider default applies to tiles added from
-    /// here on, and never rewrites one already on a screen.
+    /// Two paths reach that: the explicit "All providers" choice, and a
+    /// configurable tile whose stored parameter is absent. The original
+    /// static tiles do not come through this intent at all; their separate
+    /// compatibility definition always draws every provider.
     var chosenProviderID: String? {
         guard let id = provider?.id,
               id != HeadroomProviderEntity.everyProviderID

--- a/widget/HeadroomWidgetIntent.swift
+++ b/widget/HeadroomWidgetIntent.swift
@@ -111,11 +111,10 @@ struct HeadroomWidgetConfiguration: WidgetConfigurationIntent {
 
     /// Nil when the tile draws everything it is given.
     ///
-    /// Two paths reach that: the explicit "All providers" choice, and a tile
-    /// placed before this configuration existed, which carries no parameter at
-    /// all. Both drew every provider before and both keep drawing every
-    /// provider — the new single-provider default applies to tiles added from
-    /// here on, and never rewrites one already on a screen.
+    /// Two paths reach that: the explicit "All providers" choice, and an
+    /// editable tile whose stored parameter is absent. The original static
+    /// tiles do not come through this intent at all; their separate
+    /// compatibility definition always draws every provider.
     var chosenProviderID: String? {
         guard let id = provider?.id,
               id != HeadroomProviderEntity.everyProviderID


### PR DESCRIPTION
codex did a couple of things, and now my desktop widgets work. i'm not sure it wasn't just a hard restart. but if it isn't working on your computer maybe this will fix it

<img width="383" height="189" alt="image" src="https://github.com/user-attachments/assets/1a39684b-dccc-406b-baf1-a8b18bc46a52" />
